### PR TITLE
DOPE-208 add an order by asc and desc + tests

### DIFF
--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/ClauseBuilder.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/ClauseBuilder.kt
@@ -50,7 +50,7 @@ class ClauseBuilder(private val clauses: List<Clause>) {
 
     fun orderBy(stringField: Field<StringType>): Limit = Limit(addClause(OrderByClause(stringField)))
 
-    fun orderBy(stringField: Field<StringType>, orderByType: OrderByType) : Limit =
+    fun orderBy(stringField: Field<StringType>, orderByType: OrderByType): Limit =
         Limit(addClause(OrderByTypeClause(stringField, orderByType)))
 
     fun limit(numberExpression: TypeExpression<NumberType>): Offset = Offset(addClause(LimitClause(numberExpression)))

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/ClauseBuilder.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/ClauseBuilder.kt
@@ -6,6 +6,7 @@ import ch.ergon.dope.resolvable.clause.select.GroupByClause
 import ch.ergon.dope.resolvable.clause.select.LimitClause
 import ch.ergon.dope.resolvable.clause.select.OffsetClause
 import ch.ergon.dope.resolvable.clause.select.OrderByClause
+import ch.ergon.dope.resolvable.clause.select.OrderByTypeClause
 import ch.ergon.dope.resolvable.clause.select.SelectClause
 import ch.ergon.dope.resolvable.clause.select.SelectDistinctClause
 import ch.ergon.dope.resolvable.clause.select.SelectRawClause
@@ -16,6 +17,7 @@ import ch.ergon.dope.resolvable.clause.select.factory.GroupBy
 import ch.ergon.dope.resolvable.clause.select.factory.Limit
 import ch.ergon.dope.resolvable.clause.select.factory.Offset
 import ch.ergon.dope.resolvable.clause.select.factory.OrderBy
+import ch.ergon.dope.resolvable.clause.select.factory.OrderByType
 import ch.ergon.dope.resolvable.clause.select.factory.Where
 import ch.ergon.dope.resolvable.expression.Expression
 import ch.ergon.dope.resolvable.expression.TypeExpression
@@ -47,6 +49,9 @@ class ClauseBuilder(private val clauses: List<Clause>) {
     fun groupBy(field: Field<out ValidType>, vararg fields: Field<out ValidType>): OrderBy = OrderBy(addClause(GroupByClause(field, *fields)))
 
     fun orderBy(stringField: Field<StringType>): Limit = Limit(addClause(OrderByClause(stringField)))
+
+    fun orderBy(stringField: Field<StringType>, orderByType: OrderByType) : Limit =
+        Limit(addClause(OrderByTypeClause(stringField, orderByType)))
 
     fun limit(numberExpression: TypeExpression<NumberType>): Offset = Offset(addClause(LimitClause(numberExpression)))
 

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/OrderByClause.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/OrderByClause.kt
@@ -1,10 +1,15 @@
 package ch.ergon.dope.resolvable.clause.select
 
 import ch.ergon.dope.resolvable.clause.Clause
+import ch.ergon.dope.resolvable.clause.select.factory.OrderByType
 import ch.ergon.dope.resolvable.expression.unaliased.type.Field
 import ch.ergon.dope.resolvable.formatToQueryString
 import ch.ergon.dope.validtype.StringType
 
 class OrderByClause(private val stringField: Field<StringType>) : Clause {
     override fun toQueryString(): String = formatToQueryString("ORDER BY", stringField)
+}
+
+class OrderByTypeClause(private val stringField: Field<StringType>, private val orderByType: OrderByType) : Clause {
+    override fun toQueryString(): String = formatToQueryString("ORDER BY", stringField.toQueryString(), orderByType.type)
 }

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/factory/OrderBy.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/factory/OrderBy.kt
@@ -7,4 +7,9 @@ import ch.ergon.dope.validtype.StringType
 
 open class OrderBy(clauses: List<Clause>) : Limit(clauses) {
     fun orderBy(stringField: Field<StringType>): Limit = ClauseBuilder(clauses).orderBy(stringField)
+    fun orderBy(stringField: Field<StringType>, orderByType: OrderByType): Limit = ClauseBuilder(clauses).orderBy(stringField, orderByType)
+}
+
+enum class OrderByType(val type: String) {
+    ASC("ASC"), DESC("DESC")
 }

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/factory/OrderBy.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/select/factory/OrderBy.kt
@@ -11,5 +11,6 @@ open class OrderBy(clauses: List<Clause>) : Limit(clauses) {
 }
 
 enum class OrderByType(val type: String) {
-    ASC("ASC"), DESC("DESC")
+    ASC("ASC"),
+    DESC("DESC")
 }

--- a/core/src/test/kotlin/ch/ergon/dope/OrderByTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/OrderByTest.kt
@@ -6,12 +6,10 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 class OrderByTest {
-    private lateinit var builder: StringBuilder
     private lateinit var create: DSLContext
 
     @BeforeTest
     fun setup() {
-        builder = StringBuilder()
         create = DSLContext()
     }
 
@@ -19,12 +17,12 @@ class OrderByTest {
     fun `should add an Order By clause to the end`() {
         val expected = "SELECT * FROM person ORDER BY person.fname"
 
-        val actual : String = create
+        val actual: String = create
             .selectAll()
             .from(
                 TestBucket.Person,
             ).orderBy(
-                TestBucket.Person.fname
+                TestBucket.Person.fname,
             ).build()
 
         assertEquals(expected, actual)
@@ -34,13 +32,13 @@ class OrderByTest {
     fun `should add an Order By Ascending clause`() {
         val expected = "SELECT * FROM person ORDER BY person.fname ASC"
 
-        val actual : String = create
+        val actual: String = create
             .selectAll()
             .from(
                 TestBucket.Person,
             ).orderBy(
                 TestBucket.Person.fname,
-                OrderByType.ASC
+                OrderByType.ASC,
             ).build()
 
         assertEquals(expected, actual)
@@ -50,13 +48,13 @@ class OrderByTest {
     fun `should add an Order By Descending clause`() {
         val expected = "SELECT * FROM person ORDER BY person.fname DESC"
 
-        val actual : String = create
+        val actual: String = create
             .selectAll()
             .from(
                 TestBucket.Person,
             ).orderBy(
                 TestBucket.Person.fname,
-                OrderByType.DESC
+                OrderByType.DESC,
             ).build()
 
         assertEquals(expected, actual)

--- a/core/src/test/kotlin/ch/ergon/dope/OrderByTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/OrderByTest.kt
@@ -1,0 +1,64 @@
+package ch.ergon.dope
+
+import ch.ergon.dope.resolvable.clause.select.factory.OrderByType
+import junit.framework.TestCase.assertEquals
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class OrderByTest {
+    private lateinit var builder: StringBuilder
+    private lateinit var create: DSLContext
+
+    @BeforeTest
+    fun setup() {
+        builder = StringBuilder()
+        create = DSLContext()
+    }
+
+    @Test
+    fun `should add an Order By clause to the end`() {
+        val expected = "SELECT * FROM person ORDER BY person.fname"
+
+        val actual : String = create
+            .selectAll()
+            .from(
+                TestBucket.Person,
+            ).orderBy(
+                TestBucket.Person.fname
+            ).build()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should add an Order By Ascending clause`() {
+        val expected = "SELECT * FROM person ORDER BY person.fname ASC"
+
+        val actual : String = create
+            .selectAll()
+            .from(
+                TestBucket.Person,
+            ).orderBy(
+                TestBucket.Person.fname,
+                OrderByType.ASC
+            ).build()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should add an Order By Descending clause`() {
+        val expected = "SELECT * FROM person ORDER BY person.fname DESC"
+
+        val actual : String = create
+            .selectAll()
+            .from(
+                TestBucket.Person,
+            ).orderBy(
+                TestBucket.Person.fname,
+                OrderByType.DESC
+            ).build()
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
as per ticket DOPE-208, added an enum for ORDER BY types ASC and DESC, a function to add the clause to the query and tests