### PR TITLE
DOPE-236: conditional functions of unknowns

### DIFF
--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/model/SetClause.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/clause/model/SetClause.kt
@@ -1,6 +1,7 @@
 package ch.ergon.dope.resolvable.clause.model
 
 import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.Resolvable
 import ch.ergon.dope.resolvable.clause.IUpdateSetClause
 import ch.ergon.dope.resolvable.expression.TypeExpression
 import ch.ergon.dope.resolvable.expression.unaliased.type.Field
@@ -64,8 +65,8 @@ class SetClause(
 class SetAssignment<T : ValidType>(
     private val field: Field<T>,
     private val value: TypeExpression<T>,
-) {
-    fun toDopeQuery(): DopeQuery {
+) : Resolvable {
+    override fun toDopeQuery(): DopeQuery {
         val fieldDopeQuery = field.toDopeQuery()
         val valueDopeQuery = value.toDopeQuery()
         return DopeQuery(

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/aggregator/CountExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/aggregator/CountExpression.kt
@@ -21,7 +21,7 @@ class CountExpression(
     }
 }
 
-class CountAsteriskExpression : UnaliasedExpression<ValidType> {
+class CountAsteriskExpression : UnaliasedExpression<NumberType> {
     override fun toDopeQuery() = DopeQuery(
         queryString = "COUNT($ASTERISK_STRING)",
         parameters = emptyMap(),

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/ConditionalExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/ConditionalExpression.kt
@@ -1,0 +1,31 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.expression.TypeExpression
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.operator.FunctionOperator
+import ch.ergon.dope.validtype.ValidType
+
+sealed class ConditionalExpression<T : ValidType>(
+    private val symbol: String,
+    private val firstExpression: UnaliasedExpression<T>,
+    private val secondExpression: UnaliasedExpression<T>,
+    private vararg val additionalExpressions: UnaliasedExpression<T>,
+) : TypeExpression<T>, FunctionOperator {
+    override fun toDopeQuery(): DopeQuery {
+        val firstExpressionDopeQuery = firstExpression.toDopeQuery()
+        val secondExpressionDopeQuery = secondExpression.toDopeQuery()
+        val additionalExpressionsDopeQuery = additionalExpressions.map { it.toDopeQuery() }
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                symbol,
+                firstExpressionDopeQuery,
+                secondExpressionDopeQuery,
+                *additionalExpressionsDopeQuery.toTypedArray(),
+            ),
+            parameters = firstExpressionDopeQuery.parameters + additionalExpressionsDopeQuery.fold(
+                secondExpressionDopeQuery.parameters,
+            ) { expressionParameters, expression -> expressionParameters + expression.parameters },
+        )
+    }
+}

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
@@ -1,0 +1,42 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.expression.TypeExpression
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.operator.FunctionOperator
+import ch.ergon.dope.validtype.ValidType
+
+class DecodeExpression<T : ValidType, U : ValidType>(
+    private val expression: UnaliasedExpression<T>,
+    private val searchResultExpression: SearchResultExpression<T, U>,
+    private vararg val searchResultExpressions: SearchResultExpression<T, U>,
+    private val default: UnaliasedExpression<U>? = null,
+) : TypeExpression<U>, FunctionOperator {
+    override fun toDopeQuery(): DopeQuery {
+        val expressionDopeQuery = expression.toDopeQuery()
+        val searchResultExpressionDopeQuery = searchResultExpression.toDopeQuery()
+        val searchResultExpressionsDopeQuery = searchResultExpressions.map { it.toDopeQuery() }.toTypedArray()
+        val defaultDopeQuery = default?.toDopeQuery()
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                "DECODE",
+                expressionDopeQuery,
+                searchResultExpressionDopeQuery,
+                *searchResultExpressionsDopeQuery,
+                defaultDopeQuery,
+            ),
+            parameters = expressionDopeQuery.parameters +
+                searchResultExpressionsDopeQuery.fold(searchResultExpressionDopeQuery.parameters) {
+                        expressionParameters, expression ->
+                    expressionParameters + expression.parameters
+                } + defaultDopeQuery?.parameters.orEmpty(),
+        )
+    }
+}
+
+fun <T : ValidType, U : ValidType> decode(
+    expression: UnaliasedExpression<T>,
+    searchResultExpression: SearchResultExpression<T, U>,
+    vararg searchResultExpressions: SearchResultExpression<T, U>,
+    default: UnaliasedExpression<U>? = null,
+) = DecodeExpression(expression, searchResultExpression, *searchResultExpressions, default = default)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
@@ -7,25 +7,25 @@ import ch.ergon.dope.resolvable.operator.FunctionOperator
 import ch.ergon.dope.validtype.ValidType
 
 class DecodeExpression<T : ValidType, U : ValidType>(
-    private val expression: UnaliasedExpression<T>,
+    private val decodeExpression: UnaliasedExpression<T>,
     private val searchResult: SearchResult<T, U>,
     private vararg val searchResults: SearchResult<T, U>,
     private val default: UnaliasedExpression<U>? = null,
 ) : TypeExpression<U>, FunctionOperator {
     override fun toDopeQuery(): DopeQuery {
-        val expressionDopeQuery = expression.toDopeQuery()
+        val decodeExpressionDopeQuery = decodeExpression.toDopeQuery()
         val searchResultDopeQuery = searchResult.toDopeQuery()
         val searchResultsDopeQuery = searchResults.map { it.toDopeQuery() }.toTypedArray()
         val defaultDopeQuery = default?.toDopeQuery()
         return DopeQuery(
             queryString = toFunctionQueryString(
                 "DECODE",
-                expressionDopeQuery,
+                decodeExpressionDopeQuery,
                 searchResultDopeQuery,
                 *searchResultsDopeQuery,
                 defaultDopeQuery,
             ),
-            parameters = expressionDopeQuery.parameters +
+            parameters = decodeExpressionDopeQuery.parameters +
                 searchResultsDopeQuery.fold(searchResultDopeQuery.parameters) {
                         expressionParameters, expression ->
                     expressionParameters + expression.parameters
@@ -35,8 +35,8 @@ class DecodeExpression<T : ValidType, U : ValidType>(
 }
 
 fun <T : ValidType, U : ValidType> decode(
-    expression: UnaliasedExpression<T>,
+    decodeExpression: UnaliasedExpression<T>,
     searchResult: SearchResult<T, U>,
     vararg searchResults: SearchResult<T, U>,
     default: UnaliasedExpression<U>? = null,
-) = DecodeExpression(expression, searchResult, *searchResults, default = default)
+) = DecodeExpression(decodeExpression, searchResult, *searchResults, default = default)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpression.kt
@@ -8,25 +8,25 @@ import ch.ergon.dope.validtype.ValidType
 
 class DecodeExpression<T : ValidType, U : ValidType>(
     private val expression: UnaliasedExpression<T>,
-    private val searchResultExpression: SearchResultExpression<T, U>,
-    private vararg val searchResultExpressions: SearchResultExpression<T, U>,
+    private val searchResult: SearchResult<T, U>,
+    private vararg val searchResults: SearchResult<T, U>,
     private val default: UnaliasedExpression<U>? = null,
 ) : TypeExpression<U>, FunctionOperator {
     override fun toDopeQuery(): DopeQuery {
         val expressionDopeQuery = expression.toDopeQuery()
-        val searchResultExpressionDopeQuery = searchResultExpression.toDopeQuery()
-        val searchResultExpressionsDopeQuery = searchResultExpressions.map { it.toDopeQuery() }.toTypedArray()
+        val searchResultDopeQuery = searchResult.toDopeQuery()
+        val searchResultsDopeQuery = searchResults.map { it.toDopeQuery() }.toTypedArray()
         val defaultDopeQuery = default?.toDopeQuery()
         return DopeQuery(
             queryString = toFunctionQueryString(
                 "DECODE",
                 expressionDopeQuery,
-                searchResultExpressionDopeQuery,
-                *searchResultExpressionsDopeQuery,
+                searchResultDopeQuery,
+                *searchResultsDopeQuery,
                 defaultDopeQuery,
             ),
             parameters = expressionDopeQuery.parameters +
-                searchResultExpressionsDopeQuery.fold(searchResultExpressionDopeQuery.parameters) {
+                searchResultsDopeQuery.fold(searchResultDopeQuery.parameters) {
                         expressionParameters, expression ->
                     expressionParameters + expression.parameters
                 } + defaultDopeQuery?.parameters.orEmpty(),
@@ -36,7 +36,7 @@ class DecodeExpression<T : ValidType, U : ValidType>(
 
 fun <T : ValidType, U : ValidType> decode(
     expression: UnaliasedExpression<T>,
-    searchResultExpression: SearchResultExpression<T, U>,
-    vararg searchResultExpressions: SearchResultExpression<T, U>,
+    searchResult: SearchResult<T, U>,
+    vararg searchResults: SearchResult<T, U>,
     default: UnaliasedExpression<U>? = null,
-) = DecodeExpression(expression, searchResultExpression, *searchResultExpressions, default = default)
+) = DecodeExpression(expression, searchResult, *searchResults, default = default)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingExpression.kt
@@ -1,0 +1,16 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.validtype.ValidType
+
+class IfMissingExpression<T : ValidType>(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) : ConditionalExpression<T>("IFMISSING", firstExpression, secondExpression, *additionalExpressions)
+
+fun <T : ValidType> ifMissing(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) = IfMissingExpression(firstExpression, secondExpression, *additionalExpressions)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingOrNullExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingOrNullExpression.kt
@@ -1,0 +1,28 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.validtype.ValidType
+
+class IfMissingOrNullExpression<T : ValidType>(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) : ConditionalExpression<T>("IFMISSINGORNULL", firstExpression, secondExpression, *additionalExpressions)
+
+fun <T : ValidType> ifMissingOrNull(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) = IfMissingOrNullExpression(firstExpression, secondExpression, *additionalExpressions)
+
+class CoalesceExpression<T : ValidType>(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) : ConditionalExpression<T>("COALESCE", firstExpression, secondExpression, *additionalExpressions)
+
+fun <T : ValidType> coalesce(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) = CoalesceExpression(firstExpression, secondExpression, *additionalExpressions)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfNullExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfNullExpression.kt
@@ -1,0 +1,16 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.validtype.ValidType
+
+class IfNullExpression<T : ValidType>(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) : ConditionalExpression<T>("IFNULL", firstExpression, secondExpression, *additionalExpressions)
+
+fun <T : ValidType> ifNull(
+    firstExpression: UnaliasedExpression<T>,
+    secondExpression: UnaliasedExpression<T>,
+    vararg additionalExpressions: UnaliasedExpression<T>,
+) = IfNullExpression(firstExpression, secondExpression, *additionalExpressions)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2Expression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2Expression.kt
@@ -1,0 +1,93 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.expression.TypeExpression
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import ch.ergon.dope.resolvable.operator.FunctionOperator
+import ch.ergon.dope.validtype.BooleanType
+import ch.ergon.dope.validtype.NumberType
+import ch.ergon.dope.validtype.StringType
+import ch.ergon.dope.validtype.ValidType
+
+class Nvl2Expression<T : ValidType>(
+    private val initialExpression: UnaliasedExpression<out ValidType>,
+    private val valueIfExists: UnaliasedExpression<T>,
+    private val valueIfNotExists: UnaliasedExpression<T>,
+) : TypeExpression<T>, FunctionOperator {
+    override fun toDopeQuery(): DopeQuery {
+        val initialExpressionDopeQuery = initialExpression.toDopeQuery()
+        val valueIfExistsDopeQuery = valueIfExists.toDopeQuery()
+        val valueIfNotExistsDopeQuery = valueIfNotExists.toDopeQuery()
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                "NVL2",
+                initialExpressionDopeQuery.queryString,
+                valueIfExistsDopeQuery.queryString,
+                valueIfNotExistsDopeQuery.queryString,
+            ),
+            parameters = initialExpressionDopeQuery.parameters + valueIfExistsDopeQuery.parameters +
+                valueIfNotExistsDopeQuery.parameters,
+        )
+    }
+}
+
+fun <T : ValidType> nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<T>,
+    valueIfNotExists: UnaliasedExpression<T>,
+) = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists)
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<NumberType>,
+    valueIfNotExists: Number,
+) = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<StringType>,
+    valueIfNotExists: String,
+) = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<BooleanType>,
+    valueIfNotExists: Boolean,
+) = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Number,
+    valueIfNotExists: UnaliasedExpression<NumberType>,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: String,
+    valueIfNotExists: UnaliasedExpression<StringType>,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Boolean,
+    valueIfNotExists: UnaliasedExpression<BooleanType>,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Number,
+    valueIfNotExists: Number,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: String,
+    valueIfNotExists: String,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Boolean,
+    valueIfNotExists: Boolean,
+) = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/NvlExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/NvlExpression.kt
@@ -1,0 +1,25 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import ch.ergon.dope.validtype.BooleanType
+import ch.ergon.dope.validtype.NumberType
+import ch.ergon.dope.validtype.StringType
+import ch.ergon.dope.validtype.ValidType
+
+class NvlExpression<T : ValidType>(
+    initialExpression: UnaliasedExpression<T>,
+    substituteExpression: UnaliasedExpression<T>,
+) : ConditionalExpression<T>("NVL", initialExpression, substituteExpression)
+
+fun <T : ValidType> nvl(initialExpression: UnaliasedExpression<T>, substituteExpression: UnaliasedExpression<T>) =
+    NvlExpression(initialExpression, substituteExpression)
+
+fun nvl(initialExpression: UnaliasedExpression<NumberType>, substituteExpression: Number) =
+    NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+fun nvl(initialExpression: UnaliasedExpression<StringType>, substituteExpression: String) =
+    NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+fun nvl(initialExpression: UnaliasedExpression<BooleanType>, substituteExpression: Boolean) =
+    NvlExpression(initialExpression, substituteExpression.toDopeType())

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResult.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResult.kt
@@ -1,6 +1,7 @@
 package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
 
 import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.Resolvable
 import ch.ergon.dope.resolvable.expression.UnaliasedExpression
 import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import ch.ergon.dope.validtype.ValidType
@@ -8,8 +9,8 @@ import ch.ergon.dope.validtype.ValidType
 class SearchResult<T : ValidType, U : ValidType>(
     private val searchExpression: UnaliasedExpression<T>,
     private val resultExpression: UnaliasedExpression<U>,
-) {
-    fun toDopeQuery(): DopeQuery {
+) : Resolvable {
+    override fun toDopeQuery(): DopeQuery {
         val searchExpressionDopeQuery = searchExpression.toDopeQuery()
         val resultExpressionDopeQuery = resultExpression.toDopeQuery()
         return DopeQuery(

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResult.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResult.kt
@@ -5,7 +5,7 @@ import ch.ergon.dope.resolvable.expression.UnaliasedExpression
 import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import ch.ergon.dope.validtype.ValidType
 
-class SearchResultExpression<T : ValidType, U : ValidType>(
+class SearchResult<T : ValidType, U : ValidType>(
     private val searchExpression: UnaliasedExpression<T>,
     private val resultExpression: UnaliasedExpression<U>,
 ) {
@@ -20,49 +20,49 @@ class SearchResultExpression<T : ValidType, U : ValidType>(
 }
 
 fun <T : ValidType, U : ValidType> UnaliasedExpression<T>.resultsIn(resultExpression: UnaliasedExpression<U>) =
-    SearchResultExpression(this, resultExpression)
+    SearchResult(this, resultExpression)
 
 fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: Number) =
-    SearchResultExpression(this, resultExpression.toDopeType())
+    SearchResult(this, resultExpression.toDopeType())
 
 fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: String) =
-    SearchResultExpression(this, resultExpression.toDopeType())
+    SearchResult(this, resultExpression.toDopeType())
 
 fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: Boolean) =
-    SearchResultExpression(this, resultExpression.toDopeType())
+    SearchResult(this, resultExpression.toDopeType())
 
 fun Number.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
-    SearchResultExpression(this.toDopeType(), resultExpression)
+    SearchResult(this.toDopeType(), resultExpression)
 
 fun String.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
-    SearchResultExpression(this.toDopeType(), resultExpression)
+    SearchResult(this.toDopeType(), resultExpression)
 
 fun Boolean.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
-    SearchResultExpression(this.toDopeType(), resultExpression)
+    SearchResult(this.toDopeType(), resultExpression)
 
 fun Number.resultsIn(resultExpression: Number) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun Number.resultsIn(resultExpression: String) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun Number.resultsIn(resultExpression: Boolean) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun String.resultsIn(resultExpression: Number) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun String.resultsIn(resultExpression: String) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun String.resultsIn(resultExpression: Boolean) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun Boolean.resultsIn(resultExpression: Number) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun Boolean.resultsIn(resultExpression: String) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())
 
 fun Boolean.resultsIn(resultExpression: Boolean) =
-    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+    SearchResult(this.toDopeType(), resultExpression.toDopeType())

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultExpression.kt
@@ -1,0 +1,68 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import ch.ergon.dope.validtype.ValidType
+
+class SearchResultExpression<T : ValidType, U : ValidType>(
+    private val searchExpression: UnaliasedExpression<T>,
+    private val resultExpression: UnaliasedExpression<U>,
+) {
+    fun toDopeQuery(): DopeQuery {
+        val searchExpressionDopeQuery = searchExpression.toDopeQuery()
+        val resultExpressionDopeQuery = resultExpression.toDopeQuery()
+        return DopeQuery(
+            queryString = "${searchExpressionDopeQuery.queryString}, ${resultExpressionDopeQuery.queryString}",
+            parameters = searchExpressionDopeQuery.parameters + resultExpressionDopeQuery.parameters,
+        )
+    }
+}
+
+fun <T : ValidType, U : ValidType> UnaliasedExpression<T>.resultsIn(resultExpression: UnaliasedExpression<U>) =
+    SearchResultExpression(this, resultExpression)
+
+fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: Number) =
+    SearchResultExpression(this, resultExpression.toDopeType())
+
+fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: String) =
+    SearchResultExpression(this, resultExpression.toDopeType())
+
+fun UnaliasedExpression<out ValidType>.resultsIn(resultExpression: Boolean) =
+    SearchResultExpression(this, resultExpression.toDopeType())
+
+fun Number.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
+    SearchResultExpression(this.toDopeType(), resultExpression)
+
+fun String.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
+    SearchResultExpression(this.toDopeType(), resultExpression)
+
+fun Boolean.resultsIn(resultExpression: UnaliasedExpression<out ValidType>) =
+    SearchResultExpression(this.toDopeType(), resultExpression)
+
+fun Number.resultsIn(resultExpression: Number) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun Number.resultsIn(resultExpression: String) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun Number.resultsIn(resultExpression: Boolean) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun String.resultsIn(resultExpression: Number) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun String.resultsIn(resultExpression: String) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun String.resultsIn(resultExpression: Boolean) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun Boolean.resultsIn(resultExpression: Number) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun Boolean.resultsIn(resultExpression: String) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())
+
+fun Boolean.resultsIn(resultExpression: Boolean) =
+    SearchResultExpression(this.toDopeType(), resultExpression.toDopeType())

--- a/core/src/test/kotlin/ch/ergon/dope/buildTest/ConditionalUnknownFunctionsTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/buildTest/ConditionalUnknownFunctionsTest.kt
@@ -1,0 +1,183 @@
+package ch.ergon.dope.buildTest
+
+import ch.ergon.dope.QueryBuilder
+import ch.ergon.dope.helper.someBucket
+import ch.ergon.dope.helper.someNumberField
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringArrayField
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.alias
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.coalesce
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.decode
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifMissing
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifMissingOrNull
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifNull
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.nvl
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.nvl2
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.resultsIn
+import ch.ergon.dope.resolvable.expression.unaliased.type.logical.and
+import ch.ergon.dope.resolvable.expression.unaliased.type.relational.isEqualTo
+import ch.ergon.dope.resolvable.expression.unaliased.type.relational.isGreaterThan
+import ch.ergon.dope.resolvable.expression.unaliased.type.stringfunction.concat
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ConditionalUnknownFunctionsTest {
+    private lateinit var create: QueryBuilder
+
+    @BeforeTest
+    fun setup() {
+        create = QueryBuilder()
+    }
+
+    @Test
+    fun `should support coalesce in query`() {
+        val expected = "SELECT COALESCE(`stringField`, CONCAT(\"some\", \"string\"), \"someString\")"
+
+        val actual = create
+            .select(
+                coalesce(
+                    someStringField(),
+                    concat("some", "string"),
+                    someString().toDopeType(),
+                ),
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support decode in query`() {
+        val bucket = someBucket("airport").alias("a")
+        val expected = "SELECT `a`.`airportname` AS `Airport`, " +
+            "DECODE(`a`.`tz`, \"Pacific/Honolulu\", -10, " +
+            "\"America/Anchorage\", -9, " +
+            "\"America/Los_Angeles\", -8, " +
+            "\"America/Denver\", -7, " +
+            "\"America/Chicago\", -6, " +
+            "\"America/New_York\", -5, 0) AS `UTCOffset` " +
+            "FROM `airport` AS `a` " +
+            "WHERE (`a`.`country` = \"United States\" AND `a`.`geo.alt` > 1000) " +
+            "LIMIT 5"
+
+        val actual = create
+            .select(
+                someStringField("airportname", bucket).alias("Airport"),
+                decode(
+                    someStringField("tz", bucket),
+                    "Pacific/Honolulu".resultsIn(-10),
+                    "America/Anchorage".resultsIn(-9),
+                    "America/Los_Angeles".resultsIn(-8),
+                    "America/Denver".resultsIn(-7),
+                    "America/Chicago".resultsIn(-6),
+                    "America/New_York".resultsIn(-5),
+                    default = 0.toDopeType(),
+                ).alias("UTCOffset"),
+            ).from(
+                bucket,
+            ).where(
+                someStringField("country", bucket).isEqualTo("United States").and(
+                    someNumberField("geo.alt", bucket).isGreaterThan(1000),
+                ),
+            ).limit(
+                5,
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing in query`() {
+        val expected = "SELECT IFMISSING(`stringField`, CONCAT(\"some\", \"string\"), \"someString\")"
+
+        val actual = create
+            .select(
+                ifMissing(
+                    someStringField(),
+                    concat("some", "string"),
+                    someString().toDopeType(),
+                ),
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing or null in query`() {
+        val expected = "SELECT IFMISSINGORNULL(`stringField`, CONCAT(\"some\", \"string\"), \"someString\")"
+
+        val actual = create
+            .select(
+                ifMissingOrNull(
+                    someStringField(),
+                    concat("some", "string"),
+                    someString().toDopeType(),
+                ),
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if null in query`() {
+        val expected = "SELECT IFNULL(`stringField`, CONCAT(\"some\", \"string\"), \"someString\")"
+
+        val actual = create
+            .select(
+                ifNull(
+                    someStringField(),
+                    concat("some", "string"),
+                    someString().toDopeType(),
+                ),
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl in query`() {
+        val expected = "SELECT `name` AS `Name`, NVL(`iata`, \"n/a\") AS `IATA` " +
+            "FROM `airline` " +
+            "LIMIT 5"
+
+        val actual = create
+            .select(
+                someStringField("name").alias("Name"),
+                nvl(
+                    someStringField("iata"),
+                    "n/a",
+                ).alias("IATA"),
+            ).from(
+                someBucket("airline"),
+            ).limit(
+                5,
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl2 in query`() {
+        val expected = "SELECT `name` AS `Name`, NVL2(`directions`, \"Yes\", \"No\") AS `DirectionsAvailable` " +
+            "FROM `hotel` " +
+            "LIMIT 5"
+
+        val actual = create
+            .select(
+                someStringField("name").alias("Name"),
+                nvl2(
+                    someStringArrayField("directions"),
+                    "Yes",
+                    "No",
+                ).alias("DirectionsAvailable"),
+            ).from(
+                someBucket("hotel"),
+            ).limit(
+                5,
+            ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/helper/Builder.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/helper/Builder.kt
@@ -1,7 +1,11 @@
 package ch.ergon.dope.helper
 
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.expression.unaliased.aggregator.CountAsteriskExpression
 import ch.ergon.dope.resolvable.expression.unaliased.type.Field
 import ch.ergon.dope.resolvable.expression.unaliased.type.TRUE
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.SearchResult
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import ch.ergon.dope.resolvable.fromable.AliasedBucket
 import ch.ergon.dope.resolvable.fromable.Bucket
 import ch.ergon.dope.resolvable.fromable.UnaliasedBucket
@@ -19,6 +23,8 @@ fun someStringField(name: String = "stringField", bucket: Bucket = someBucket(""
 fun someBooleanField(name: String = "booleanField", bucket: Bucket = someBucket("")) = Field<BooleanType>(name, getBucketName(bucket))
 
 fun someBooleanExpression() = TRUE
+
+fun someUnaliasedExpression() = CountAsteriskExpression()
 
 fun someNumberArrayField(name: String = "numberArrayField", bucket: Bucket = someBucket("")) =
     Field<ArrayType<NumberType>>(name, getBucketName(bucket))
@@ -39,3 +45,8 @@ private fun getBucketName(bucket: Bucket) = when (bucket) {
     is AliasedBucket -> bucket.alias
     is UnaliasedBucket -> bucket.name
 }
+
+fun someStringSearchNumberResult(
+    searchExpression: UnaliasedExpression<StringType> = someString().toDopeType(),
+    resultExpression: UnaliasedExpression<NumberType> = someNumber().toDopeType(),
+) = SearchResult(searchExpression, resultExpression)

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpressionTest.kt
@@ -5,6 +5,7 @@ import ch.ergon.dope.helper.ParameterDependentTest
 import ch.ergon.dope.helper.someNumber
 import ch.ergon.dope.helper.someString
 import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.helper.someStringSearchNumberResult
 import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
 import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import kotlin.test.Test
@@ -14,12 +15,12 @@ class DecodeExpressionTest : ParameterDependentTest {
     @Test
     fun `should support decode expression`() {
         val expected = DopeQuery(
-            "DECODE(`stringField`, \"someString\", 1, 0)",
+            "DECODE(`stringField`, \"someString\", 5, 0)",
             emptyMap(),
         )
         val underTest = DecodeExpression(
             someStringField(),
-            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            someStringSearchNumberResult(),
             default = someNumber(0).toDopeType(),
         )
 
@@ -32,12 +33,12 @@ class DecodeExpressionTest : ParameterDependentTest {
     fun `should support decode expression with parameter`() {
         val parameterValue = someString()
         val expected = DopeQuery(
-            "DECODE($1, \"someString\", 1, 0)",
+            "DECODE($1, \"someString\", 5, 0)",
             mapOf("$1" to parameterValue),
         )
         val underTest = DecodeExpression(
             parameterValue.asParameter(),
-            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            someStringSearchNumberResult(),
             default = someNumber(0).toDopeType(),
         )
 
@@ -50,12 +51,12 @@ class DecodeExpressionTest : ParameterDependentTest {
     fun `should support decode expression with second parameter`() {
         val parameterValue = someNumber()
         val expected = DopeQuery(
-            "DECODE(`stringField`, \"someString\", 1, $1)",
+            "DECODE(`stringField`, \"someString\", 5, $1)",
             mapOf("$1" to parameterValue),
         )
         val underTest = DecodeExpression(
             someStringField(),
-            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            someStringSearchNumberResult(),
             default = parameterValue.asParameter(),
         )
 
@@ -69,12 +70,12 @@ class DecodeExpressionTest : ParameterDependentTest {
         val parameterValue = someString()
         val parameterValue2 = someNumber()
         val expected = DopeQuery(
-            "DECODE($1, \"someString\", 1, $2)",
+            "DECODE($1, \"someString\", 5, $2)",
             mapOf("$1" to parameterValue, "$2" to parameterValue2),
         )
         val underTest = DecodeExpression(
             parameterValue.asParameter(),
-            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            someStringSearchNumberResult(),
             default = parameterValue2.asParameter(),
         )
 
@@ -86,10 +87,10 @@ class DecodeExpressionTest : ParameterDependentTest {
     @Test
     fun `should support decode extension function`() {
         val expression = someStringField()
-        val searchResultExpression = someString().resultsIn(someNumber())
-        val expected = DecodeExpression(expression, searchResultExpression)
+        val searchResult = someStringSearchNumberResult()
+        val expected = DecodeExpression(expression, searchResult)
 
-        val actual = decode(expression, searchResultExpression)
+        val actual = decode(expression, searchResult)
 
         assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
     }
@@ -97,11 +98,11 @@ class DecodeExpressionTest : ParameterDependentTest {
     @Test
     fun `should support decode extension function with default`() {
         val expression = someStringField()
-        val searchResultExpression = someString().resultsIn(someNumber())
+        val searchResult = someStringSearchNumberResult()
         val default = someNumber().toDopeType()
-        val expected = DecodeExpression(expression, searchResultExpression, default = default)
+        val expected = DecodeExpression(expression, searchResult, default = default)
 
-        val actual = decode(expression, searchResultExpression, default = default)
+        val actual = decode(expression, searchResult, default = default)
 
         assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
     }

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/DecodeExpressionTest.kt
@@ -1,0 +1,108 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DecodeExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support decode expression`() {
+        val expected = DopeQuery(
+            "DECODE(`stringField`, \"someString\", 1, 0)",
+            emptyMap(),
+        )
+        val underTest = DecodeExpression(
+            someStringField(),
+            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            default = someNumber(0).toDopeType(),
+        )
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support decode expression with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "DECODE($1, \"someString\", 1, 0)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = DecodeExpression(
+            parameterValue.asParameter(),
+            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            default = someNumber(0).toDopeType(),
+        )
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support decode expression with second parameter`() {
+        val parameterValue = someNumber()
+        val expected = DopeQuery(
+            "DECODE(`stringField`, \"someString\", 1, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = DecodeExpression(
+            someStringField(),
+            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            default = parameterValue.asParameter(),
+        )
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support decode expression with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someNumber()
+        val expected = DopeQuery(
+            "DECODE($1, \"someString\", 1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = DecodeExpression(
+            parameterValue.asParameter(),
+            someString().toDopeType().resultsIn(someNumber(1).toDopeType()),
+            default = parameterValue2.asParameter(),
+        )
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support decode extension function`() {
+        val expression = someStringField()
+        val searchResultExpression = someString().resultsIn(someNumber())
+        val expected = DecodeExpression(expression, searchResultExpression)
+
+        val actual = decode(expression, searchResultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support decode extension function with default`() {
+        val expression = someStringField()
+        val searchResultExpression = someString().resultsIn(someNumber())
+        val default = someNumber().toDopeType()
+        val expected = DecodeExpression(expression, searchResultExpression, default = default)
+
+        val actual = decode(expression, searchResultExpression, default = default)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingExpressionTest.kt
@@ -1,0 +1,78 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfMissingExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support if missing`() {
+        val expected = DopeQuery(
+            "IFMISSING(`stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = IfMissingExpression(someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFMISSING($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfMissingExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFMISSING(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfMissingExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "IFMISSING($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = IfMissingExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing function`() {
+        val firstExpression = someStringField()
+        val secondExpression = someStringField()
+        val expected = IfMissingExpression(firstExpression, secondExpression)
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingOrNullExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfMissingOrNullExpressionTest.kt
@@ -1,0 +1,145 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfMissingOrNullExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support if missing or null`() {
+        val expected = DopeQuery(
+            "IFMISSINGORNULL(`stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = IfMissingOrNullExpression(someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing or null with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFMISSINGORNULL($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfMissingOrNullExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing or null with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFMISSINGORNULL(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfMissingOrNullExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing or null with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "IFMISSINGORNULL($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = IfMissingOrNullExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if missing or null function`() {
+        val firstExpression = someStringField()
+        val secondExpression = someStringField()
+        val expected = IfMissingOrNullExpression(firstExpression, secondExpression)
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce`() {
+        val expected = DopeQuery(
+            "COALESCE(`stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = CoalesceExpression(someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support coalesce with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "COALESCE($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = CoalesceExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support coalesce with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "COALESCE(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = CoalesceExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support coalesce with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "COALESCE($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = CoalesceExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support coalesce function`() {
+        val firstExpression = someStringField()
+        val secondExpression = someStringField()
+        val expected = CoalesceExpression(firstExpression, secondExpression)
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfNullExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/IfNullExpressionTest.kt
@@ -1,0 +1,78 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfNullExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support if null`() {
+        val expected = DopeQuery(
+            "IFNULL(`stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = IfNullExpression(someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if null with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFNULL($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfNullExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if null with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "IFNULL(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = IfNullExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if null with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "IFNULL($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = IfNullExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support if null function`() {
+        val firstExpression = someStringField()
+        val secondExpression = someStringField()
+        val expected = IfNullExpression(firstExpression, secondExpression)
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2ExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2ExpressionTest.kt
@@ -8,6 +8,7 @@ import ch.ergon.dope.helper.someNumber
 import ch.ergon.dope.helper.someNumberField
 import ch.ergon.dope.helper.someString
 import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.helper.someUnaliasedExpression
 import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
 import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import kotlin.test.Test
@@ -28,13 +29,13 @@ class Nvl2ExpressionTest : ParameterDependentTest {
     }
 
     @Test
-    fun `should support nvl with parameter`() {
+    fun `should support nvl2 with parameter`() {
         val parameterValue = someString()
         val expected = DopeQuery(
-            "NVL($1, `stringField`)",
+            "NVL2($1, `stringField`, `stringField`)",
             mapOf("$1" to parameterValue),
         )
-        val underTest = NvlExpression(parameterValue.asParameter(), someStringField())
+        val underTest = Nvl2Expression(parameterValue.asParameter(), someStringField(), someStringField())
 
         val actual = underTest.toDopeQuery()
 
@@ -42,13 +43,13 @@ class Nvl2ExpressionTest : ParameterDependentTest {
     }
 
     @Test
-    fun `should support nvl with second parameter`() {
+    fun `should support nvl2 with second parameter`() {
         val parameterValue = someString()
         val expected = DopeQuery(
-            "NVL(`stringField`, $1)",
+            "NVL2(`booleanField`, $1, `stringField`)",
             mapOf("$1" to parameterValue),
         )
-        val underTest = NvlExpression(someStringField(), parameterValue.asParameter())
+        val underTest = Nvl2Expression(someBooleanField(), parameterValue.asParameter(), someStringField())
 
         val actual = underTest.toDopeQuery()
 
@@ -56,14 +57,58 @@ class Nvl2ExpressionTest : ParameterDependentTest {
     }
 
     @Test
-    fun `should support nvl with all parameters`() {
+    fun `should support nvl2 with third parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "NVL2(`booleanField`, `stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = Nvl2Expression(someBooleanField(), someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl2 with first and second parameters`() {
+        val parameterValue = someBoolean()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "NVL2($1, $2, `stringField`)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = Nvl2Expression(parameterValue.asParameter(), parameterValue2.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl2 with first and third parameters`() {
+        val parameterValue = someBoolean()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "NVL2($1, `stringField`, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = Nvl2Expression(parameterValue.asParameter(), someStringField(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl2 with second and third parameters`() {
         val parameterValue = someString()
         val parameterValue2 = someString()
         val expected = DopeQuery(
-            "NVL($1, $2)",
+            "NVL2(`booleanField`, $1, $2)",
             mapOf("$1" to parameterValue, "$2" to parameterValue2),
         )
-        val underTest = NvlExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+        val underTest = Nvl2Expression(someBooleanField(), parameterValue.asParameter(), parameterValue2.asParameter())
 
         val actual = underTest.toDopeQuery()
 
@@ -71,45 +116,137 @@ class Nvl2ExpressionTest : ParameterDependentTest {
     }
 
     @Test
-    fun `should support nvl function expression expression`() {
-        val initialExpression = someStringField()
-        val substituteExpression = someStringField()
-        val expected = NvlExpression(initialExpression, substituteExpression)
+    fun `should support nvl2 with all parameters`() {
+        val parameterValue = someBoolean()
+        val parameterValue2 = someString()
+        val parameterValue3 = someString()
+        val expected = DopeQuery(
+            "NVL2($1, $2, $3)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2, "$3" to parameterValue3),
+        )
+        val underTest = Nvl2Expression(parameterValue.asParameter(), parameterValue2.asParameter(), parameterValue3.asParameter())
 
-        val actual = nvl(initialExpression, substituteExpression)
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl2 function expression expression`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someStringField()
+        val valueIfNotExists = someStringField()
+        val expected = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists)
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
 
         assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
     }
 
     @Test
-    fun `should support nvl function expression number`() {
-        val initialExpression = someNumberField()
-        val substituteExpression = someNumber()
-        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+    fun `should support nvl2 function expression number`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someNumberField()
+        val valueIfNotExists = someNumber()
+        val expected = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
 
-        val actual = nvl(initialExpression, substituteExpression)
-
-        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
-    }
-
-    @Test
-    fun `should support nvl function expression string`() {
-        val initialExpression = someStringField()
-        val substituteExpression = someString()
-        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
-
-        val actual = nvl(initialExpression, substituteExpression)
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
 
         assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
     }
 
     @Test
-    fun `should support nvl function expression boolean`() {
-        val initialExpression = someBooleanField()
-        val substituteExpression = someBoolean()
-        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+    fun `should support nvl2 function expression string`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someStringField()
+        val valueIfNotExists = someString()
+        val expected = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
 
-        val actual = nvl(initialExpression, substituteExpression)
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function expression boolean`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someBooleanField()
+        val valueIfNotExists = someBoolean()
+        val expected = Nvl2Expression(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function number expression`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someNumber()
+        val valueIfNotExists = someNumberField()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function string expression`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someString()
+        val valueIfNotExists = someStringField()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function boolean expression`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someBoolean()
+        val valueIfNotExists = someBooleanField()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function number number`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someNumber()
+        val valueIfNotExists = someNumber()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function string string`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someString()
+        val valueIfNotExists = someString()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 function boolean boolean`() {
+        val initialExpression = someUnaliasedExpression()
+        val valueIfExists = someBoolean()
+        val valueIfNotExists = someBoolean()
+        val expected = Nvl2Expression(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(initialExpression, valueIfExists, valueIfNotExists)
 
         assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
     }

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2ExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/Nvl2ExpressionTest.kt
@@ -1,0 +1,116 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someBoolean
+import ch.ergon.dope.helper.someBooleanField
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someNumberField
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Nvl2ExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support nvl2`() {
+        val expected = DopeQuery(
+            "NVL2(`booleanField`, `stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = Nvl2Expression(someBooleanField(), someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "NVL($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = NvlExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "NVL(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = NvlExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "NVL($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = NvlExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl function expression expression`() {
+        val initialExpression = someStringField()
+        val substituteExpression = someStringField()
+        val expected = NvlExpression(initialExpression, substituteExpression)
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression number`() {
+        val initialExpression = someNumberField()
+        val substituteExpression = someNumber()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression string`() {
+        val initialExpression = someStringField()
+        val substituteExpression = someString()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression boolean`() {
+        val initialExpression = someBooleanField()
+        val substituteExpression = someBoolean()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/NvlExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/NvlExpressionTest.kt
@@ -1,0 +1,116 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someBoolean
+import ch.ergon.dope.helper.someBooleanField
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someNumberField
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NvlExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support nvl`() {
+        val expected = DopeQuery(
+            "NVL(`stringField`, `stringField`)",
+            emptyMap(),
+        )
+        val underTest = NvlExpression(someStringField(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "NVL($1, `stringField`)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = NvlExpression(parameterValue.asParameter(), someStringField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with second parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "NVL(`stringField`, $1)",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = NvlExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someString()
+        val expected = DopeQuery(
+            "NVL($1, $2)",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = NvlExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support nvl function expression expression`() {
+        val initialExpression = someStringField()
+        val substituteExpression = someStringField()
+        val expected = NvlExpression(initialExpression, substituteExpression)
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression number`() {
+        val initialExpression = someNumberField()
+        val substituteExpression = someNumber()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression string`() {
+        val initialExpression = someStringField()
+        val substituteExpression = someString()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl function expression boolean`() {
+        val initialExpression = someBooleanField()
+        val substituteExpression = someBoolean()
+        val expected = NvlExpression(initialExpression, substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultExpressionTest.kt
@@ -1,0 +1,247 @@
+package ch.ergon.dope.resolvable.expression.unaliased.type.conditional
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.helper.ParameterDependentTest
+import ch.ergon.dope.helper.someBoolean
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someNumberField
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.unaliased.type.asParameter
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchResultExpressionTest : ParameterDependentTest {
+    @Test
+    fun `should support search result expression`() {
+        val expected = DopeQuery(
+            "`stringField`, `numberField`",
+            emptyMap(),
+        )
+        val underTest = SearchResultExpression(someStringField(), someNumberField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search result expression with parameter`() {
+        val parameterValue = someString()
+        val expected = DopeQuery(
+            "$1, `numberField`",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = SearchResultExpression(parameterValue.asParameter(), someNumberField())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search result expression with second parameter`() {
+        val parameterValue = someNumber()
+        val expected = DopeQuery(
+            "`stringField`, $1",
+            mapOf("$1" to parameterValue),
+        )
+        val underTest = SearchResultExpression(someStringField(), parameterValue.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search result expression with all parameters`() {
+        val parameterValue = someString()
+        val parameterValue2 = someNumber()
+        val expected = DopeQuery(
+            "$1, $2",
+            mapOf("$1" to parameterValue, "$2" to parameterValue2),
+        )
+        val underTest = SearchResultExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+
+        val actual = underTest.toDopeQuery()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search result extension function with unaliased unaliased`() {
+        val searchExpression = someStringField()
+        val resultExpression = someNumberField()
+        val expected = SearchResultExpression(searchExpression, resultExpression)
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with unaliased number`() {
+        val searchExpression = someStringField()
+        val resultExpression = someNumber()
+        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with unaliased string`() {
+        val searchExpression = someStringField()
+        val resultExpression = someString()
+        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with unaliased boolean`() {
+        val searchExpression = someStringField()
+        val resultExpression = someBoolean()
+        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with number unaliased`() {
+        val searchExpression = someNumber()
+        val resultExpression = someStringField()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with string unaliased`() {
+        val searchExpression = someString()
+        val resultExpression = someStringField()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with boolean unaliased`() {
+        val searchExpression = someBoolean()
+        val resultExpression = someStringField()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with number number`() {
+        val searchExpression = someNumber()
+        val resultExpression = someNumber()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with number string`() {
+        val searchExpression = someNumber()
+        val resultExpression = someString()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with number boolean`() {
+        val searchExpression = someNumber()
+        val resultExpression = someBoolean()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with string number`() {
+        val searchExpression = someString()
+        val resultExpression = someNumber()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with string string`() {
+        val searchExpression = someString()
+        val resultExpression = someString()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with string boolean`() {
+        val searchExpression = someString()
+        val resultExpression = someBoolean()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with boolean number`() {
+        val searchExpression = someBoolean()
+        val resultExpression = someNumber()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with boolean string`() {
+        val searchExpression = someBoolean()
+        val resultExpression = someString()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support search result extension function with boolean boolean`() {
+        val searchExpression = someBoolean()
+        val resultExpression = someBoolean()
+        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+
+        val actual = searchExpression.resultsIn(resultExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/unaliased/type/conditional/SearchResultTest.kt
@@ -12,14 +12,14 @@ import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class SearchResultExpressionTest : ParameterDependentTest {
+class SearchResultTest : ParameterDependentTest {
     @Test
     fun `should support search result expression`() {
         val expected = DopeQuery(
             "`stringField`, `numberField`",
             emptyMap(),
         )
-        val underTest = SearchResultExpression(someStringField(), someNumberField())
+        val underTest = SearchResult(someStringField(), someNumberField())
 
         val actual = underTest.toDopeQuery()
 
@@ -33,7 +33,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
             "$1, `numberField`",
             mapOf("$1" to parameterValue),
         )
-        val underTest = SearchResultExpression(parameterValue.asParameter(), someNumberField())
+        val underTest = SearchResult(parameterValue.asParameter(), someNumberField())
 
         val actual = underTest.toDopeQuery()
 
@@ -47,7 +47,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
             "`stringField`, $1",
             mapOf("$1" to parameterValue),
         )
-        val underTest = SearchResultExpression(someStringField(), parameterValue.asParameter())
+        val underTest = SearchResult(someStringField(), parameterValue.asParameter())
 
         val actual = underTest.toDopeQuery()
 
@@ -62,7 +62,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
             "$1, $2",
             mapOf("$1" to parameterValue, "$2" to parameterValue2),
         )
-        val underTest = SearchResultExpression(parameterValue.asParameter(), parameterValue2.asParameter())
+        val underTest = SearchResult(parameterValue.asParameter(), parameterValue2.asParameter())
 
         val actual = underTest.toDopeQuery()
 
@@ -73,7 +73,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with unaliased unaliased`() {
         val searchExpression = someStringField()
         val resultExpression = someNumberField()
-        val expected = SearchResultExpression(searchExpression, resultExpression)
+        val expected = SearchResult(searchExpression, resultExpression)
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -84,7 +84,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with unaliased number`() {
         val searchExpression = someStringField()
         val resultExpression = someNumber()
-        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression, resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -95,7 +95,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with unaliased string`() {
         val searchExpression = someStringField()
         val resultExpression = someString()
-        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression, resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -106,7 +106,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with unaliased boolean`() {
         val searchExpression = someStringField()
         val resultExpression = someBoolean()
-        val expected = SearchResultExpression(searchExpression, resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression, resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -117,7 +117,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with number unaliased`() {
         val searchExpression = someNumber()
         val resultExpression = someStringField()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression)
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -128,7 +128,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with string unaliased`() {
         val searchExpression = someString()
         val resultExpression = someStringField()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression)
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -139,7 +139,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with boolean unaliased`() {
         val searchExpression = someBoolean()
         val resultExpression = someStringField()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression)
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression)
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -150,7 +150,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with number number`() {
         val searchExpression = someNumber()
         val resultExpression = someNumber()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -161,7 +161,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with number string`() {
         val searchExpression = someNumber()
         val resultExpression = someString()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -172,7 +172,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with number boolean`() {
         val searchExpression = someNumber()
         val resultExpression = someBoolean()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -183,7 +183,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with string number`() {
         val searchExpression = someString()
         val resultExpression = someNumber()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -194,7 +194,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with string string`() {
         val searchExpression = someString()
         val resultExpression = someString()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -205,7 +205,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with string boolean`() {
         val searchExpression = someString()
         val resultExpression = someBoolean()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -216,7 +216,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with boolean number`() {
         val searchExpression = someBoolean()
         val resultExpression = someNumber()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -227,7 +227,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with boolean string`() {
         val searchExpression = someBoolean()
         val resultExpression = someString()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 
@@ -238,7 +238,7 @@ class SearchResultExpressionTest : ParameterDependentTest {
     fun `should support search result extension function with boolean boolean`() {
         val searchExpression = someBoolean()
         val resultExpression = someBoolean()
-        val expected = SearchResultExpression(searchExpression.toDopeType(), resultExpression.toDopeType())
+        val expected = SearchResult(searchExpression.toDopeType(), resultExpression.toDopeType())
 
         val actual = searchExpression.resultsIn(resultExpression)
 

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfMissing.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfMissing.kt
@@ -1,0 +1,72 @@
+package ch.ergon.dope.extension.type.conditional
+
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifMissing
+import ch.ergon.dope.toDopeType
+import com.schwarz.crystalapi.schema.CMField
+import com.schwarz.crystalapi.schema.CMList
+
+@JvmName("ifCMNumberFieldIsMissing")
+fun ifMissing(
+    firstExpression: CMField<out Number>,
+    secondExpression: CMField<out Number>,
+    vararg additionalExpressions: CMField<out Number>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringFieldIsMissing")
+fun ifMissing(
+    firstExpression: CMField<String>,
+    secondExpression: CMField<String>,
+    vararg additionalExpressions: CMField<String>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanFieldIsMissing")
+fun ifMissing(
+    firstExpression: CMField<Boolean>,
+    secondExpression: CMField<Boolean>,
+    vararg additionalExpressions: CMField<Boolean>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMNumberStringIsMissing")
+fun ifMissing(
+    firstExpression: CMList<out Number>,
+    secondExpression: CMList<out Number>,
+    vararg additionalExpressions: CMList<out Number>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringListIsMissing")
+fun ifMissing(
+    firstExpression: CMList<String>,
+    secondExpression: CMList<String>,
+    vararg additionalExpressions: CMList<String>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanListIsMissing")
+fun ifMissing(
+    firstExpression: CMList<Boolean>,
+    secondExpression: CMList<Boolean>,
+    vararg additionalExpressions: CMList<Boolean>,
+) = ifMissing(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfMissingOrNull.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfMissingOrNull.kt
@@ -1,0 +1,139 @@
+package ch.ergon.dope.extension.type.conditional
+
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.coalesce
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifMissingOrNull
+import ch.ergon.dope.toDopeType
+import com.schwarz.crystalapi.schema.CMField
+import com.schwarz.crystalapi.schema.CMList
+
+@JvmName("ifCMNumberFieldIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMField<out Number>,
+    secondExpression: CMField<out Number>,
+    vararg additionalExpressions: CMField<out Number>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringFieldIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMField<String>,
+    secondExpression: CMField<String>,
+    vararg additionalExpressions: CMField<String>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanFieldIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMField<Boolean>,
+    secondExpression: CMField<Boolean>,
+    vararg additionalExpressions: CMField<Boolean>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMNumberListIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMList<out Number>,
+    secondExpression: CMList<out Number>,
+    vararg additionalExpressions: CMList<out Number>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringListIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMList<String>,
+    secondExpression: CMList<String>,
+    vararg additionalExpressions: CMList<String>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanListIsMissingOrNull")
+fun ifMissingOrNull(
+    firstExpression: CMList<Boolean>,
+    secondExpression: CMList<Boolean>,
+    vararg additionalExpressions: CMList<Boolean>,
+) = ifMissingOrNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMNumberField")
+fun coalesce(
+    firstExpression: CMField<out Number>,
+    secondExpression: CMField<out Number>,
+    vararg additionalExpressions: CMField<out Number>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMStringField")
+fun coalesce(
+    firstExpression: CMField<String>,
+    secondExpression: CMField<String>,
+    vararg additionalExpressions: CMField<String>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMBooleanField")
+fun coalesce(
+    firstExpression: CMField<Boolean>,
+    secondExpression: CMField<Boolean>,
+    vararg additionalExpressions: CMField<Boolean>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMNumberList")
+fun coalesce(
+    firstExpression: CMList<out Number>,
+    secondExpression: CMList<out Number>,
+    vararg additionalExpressions: CMList<out Number>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMStringList")
+fun coalesce(
+    firstExpression: CMList<String>,
+    secondExpression: CMList<String>,
+    vararg additionalExpressions: CMList<String>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("coalesceCMBooleanField")
+fun coalesce(
+    firstExpression: CMList<Boolean>,
+    secondExpression: CMList<Boolean>,
+    vararg additionalExpressions: CMList<Boolean>,
+) = coalesce(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfNull.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/IfNull.kt
@@ -1,0 +1,72 @@
+package ch.ergon.dope.extension.type.conditional
+
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.ifNull
+import ch.ergon.dope.toDopeType
+import com.schwarz.crystalapi.schema.CMField
+import com.schwarz.crystalapi.schema.CMList
+
+@JvmName("ifCMNumberFieldIsNull")
+fun ifNull(
+    firstExpression: CMField<out Number>,
+    secondExpression: CMField<out Number>,
+    vararg additionalExpressions: CMField<out Number>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringFieldIsNull")
+fun ifNull(
+    firstExpression: CMField<String>,
+    secondExpression: CMField<String>,
+    vararg additionalExpressions: CMField<String>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanFieldIsNull")
+fun ifNull(
+    firstExpression: CMField<Boolean>,
+    secondExpression: CMField<Boolean>,
+    vararg additionalExpressions: CMField<Boolean>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMNumberListIsNull")
+fun ifNull(
+    firstExpression: CMList<out Number>,
+    secondExpression: CMList<out Number>,
+    vararg additionalExpressions: CMList<out Number>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMStringListIsNull")
+fun ifNull(
+    firstExpression: CMList<String>,
+    secondExpression: CMList<String>,
+    vararg additionalExpressions: CMList<String>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)
+
+@JvmName("ifCMBooleanListIsNull")
+fun ifNull(
+    firstExpression: CMList<Boolean>,
+    secondExpression: CMList<Boolean>,
+    vararg additionalExpressions: CMList<Boolean>,
+) = ifNull(
+    firstExpression.toDopeType(),
+    secondExpression.toDopeType(),
+    *additionalExpressions.map { it.toDopeType() }.toTypedArray(),
+)

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/Nvl.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/Nvl.kt
@@ -1,0 +1,42 @@
+package ch.ergon.dope.extension.type.conditional
+
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.nvl
+import ch.ergon.dope.toDopeType
+import com.schwarz.crystalapi.schema.CMField
+import com.schwarz.crystalapi.schema.CMList
+
+@JvmName("nvlCMNumberField")
+fun nvl(initialExpression: CMField<out Number>, substituteExpression: CMField<out Number>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMStringField")
+fun nvl(initialExpression: CMField<String>, substituteExpression: CMField<String>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMBooleanField")
+fun nvl(initialExpression: CMField<Boolean>, substituteExpression: CMField<Boolean>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMNumberList")
+fun nvl(initialExpression: CMList<out Number>, substituteExpression: CMList<out Number>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMStringList")
+fun nvl(initialExpression: CMList<String>, substituteExpression: CMList<String>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMBooleanList")
+fun nvl(initialExpression: CMList<Boolean>, substituteExpression: CMList<Boolean>) =
+    nvl(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+@JvmName("nvlCMNumberFieldAndNumber")
+fun nvl(initialExpression: CMField<out Number>, substituteExpression: Number) =
+    nvl(initialExpression.toDopeType(), substituteExpression)
+
+@JvmName("nvlCMStringFieldAndString")
+fun nvl(initialExpression: CMField<String>, substituteExpression: String) =
+    nvl(initialExpression.toDopeType(), substituteExpression)
+
+@JvmName("nvlCMBooleanFieldAndBoolean")
+fun nvl(initialExpression: CMField<Boolean>, substituteExpression: Boolean) =
+    nvl(initialExpression.toDopeType(), substituteExpression)

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/Nvl2.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/type/conditional/Nvl2.kt
@@ -1,0 +1,367 @@
+package ch.ergon.dope.extension.type.conditional
+
+import ch.ergon.dope.resolvable.expression.UnaliasedExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.nvl2
+import ch.ergon.dope.toDopeType
+import ch.ergon.dope.validtype.ArrayType
+import ch.ergon.dope.validtype.BooleanType
+import ch.ergon.dope.validtype.NumberType
+import ch.ergon.dope.validtype.StringType
+import ch.ergon.dope.validtype.ValidType
+import com.schwarz.crystalapi.schema.CMField
+import com.schwarz.crystalapi.schema.CMList
+import com.schwarz.crystalapi.schema.CMType
+
+@JvmName("nvl2CMNumberFieldAndCMNumberField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMStringFieldAndCMStringField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMBooleanFieldAndCMBooleanField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMNumberListAndCMNumberList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<out Number>,
+    valueIfNotExists: CMList<out Number>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMStringListAndCMStringList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<String>,
+    valueIfNotExists: CMList<String>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMBooleanListAndCMBooleanList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<Boolean>,
+    valueIfNotExists: CMList<Boolean>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMNumberFieldAndNumberType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: UnaliasedExpression<NumberType>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringFieldAndStringType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: UnaliasedExpression<StringType>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanFieldAndBooleanType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: UnaliasedExpression<BooleanType>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMNumberListAndArrayNumberType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<out Number>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<NumberType>>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringListAndArrayStringType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<String>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<StringType>>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanListAndArrayBooleanType")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMList<Boolean>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<BooleanType>>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMNumberFieldAndNumber")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: Number,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringFieldAndString")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: String,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanFieldAndBoolean")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: Boolean,
+) = nvl2(initialExpression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2NumberTypeAndCMNumberField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<NumberType>,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2StringTypeAndCMStringField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<StringType>,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2BooleanTypeAndCMBooleanField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<BooleanType>,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayNumberTypeAndCMNumberList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<ArrayType<NumberType>>,
+    valueIfNotExists: CMList<out Number>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayStringTypeAndCMStringList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<ArrayType<StringType>>,
+    valueIfNotExists: CMList<String>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayBooleanTypeAndCMBooleanList")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: UnaliasedExpression<ArrayType<BooleanType>>,
+    valueIfNotExists: CMList<Boolean>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2NumberAndCMNumberField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: Number,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2StringAndCMStringField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: String,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2BooleanAndCMBooleanField")
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: Boolean,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: Number,
+    valueIfNotExists: Number,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists)
+
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: String,
+    valueIfNotExists: String,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists)
+
+fun nvl2(
+    initialExpression: CMType,
+    valueIfExists: Boolean,
+    valueIfNotExists: Boolean,
+) = nvl2(initialExpression.toDopeType(), valueIfExists, valueIfNotExists)
+
+@JvmName("nvl2CMNumberFieldAndCMNumberField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMStringFieldAndCMStringField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMBooleanFieldAndCMBooleanField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMNumberListAndCMNumberList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<out Number>,
+    valueIfNotExists: CMList<out Number>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMStringListAndCMStringList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<String>,
+    valueIfNotExists: CMList<String>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMBooleanListAndCMBooleanList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<Boolean>,
+    valueIfNotExists: CMList<Boolean>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+@JvmName("nvl2CMNumberFieldAndNumberType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: UnaliasedExpression<NumberType>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringFieldAndStringType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: UnaliasedExpression<StringType>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanFieldAndBooleanType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: UnaliasedExpression<BooleanType>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMNumberListAndArrayNumberType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<out Number>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<NumberType>>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringListAndArrayStringType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<String>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<StringType>>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanListAndArrayBooleanType")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMList<Boolean>,
+    valueIfNotExists: UnaliasedExpression<ArrayType<BooleanType>>,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMNumberFieldAndNumber")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<out Number>,
+    valueIfNotExists: Number,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMStringFieldAndString")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<String>,
+    valueIfNotExists: String,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2CMBooleanFieldAndBoolean")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: CMField<Boolean>,
+    valueIfNotExists: Boolean,
+) = nvl2(initialExpression, valueIfExists.toDopeType(), valueIfNotExists)
+
+@JvmName("nvl2NumberTypeAndCMNumberField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<NumberType>,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2StringTypeAndCMStringField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<StringType>,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2BooleanTypeAndCMBooleanField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<BooleanType>,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayNumberTypeAndCMNumberList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<ArrayType<NumberType>>,
+    valueIfNotExists: CMList<out Number>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayStringTypeAndCMStringList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<ArrayType<StringType>>,
+    valueIfNotExists: CMList<String>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2ArrayBooleanTypeAndCMBooleanList")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: UnaliasedExpression<ArrayType<BooleanType>>,
+    valueIfNotExists: CMList<Boolean>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2NumberAndCMNumberField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Number,
+    valueIfNotExists: CMField<out Number>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2StringAndCMStringField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: String,
+    valueIfNotExists: CMField<String>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())
+
+@JvmName("nvl2BooleanAndCMBooleanField")
+fun nvl2(
+    initialExpression: UnaliasedExpression<out ValidType>,
+    valueIfExists: Boolean,
+    valueIfNotExists: CMField<Boolean>,
+) = nvl2(initialExpression, valueIfExists, valueIfNotExists.toDopeType())

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfMissingOrNullTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfMissingOrNullTest.kt
@@ -1,0 +1,341 @@
+package ch.ergon.dope.extensions.type.conditional
+
+import ch.ergon.dope.extension.type.conditional.coalesce
+import ch.ergon.dope.extension.type.conditional.ifMissingOrNull
+import ch.ergon.dope.helper.someCMBooleanField
+import ch.ergon.dope.helper.someCMBooleanList
+import ch.ergon.dope.helper.someCMNumberField
+import ch.ergon.dope.helper.someCMNumberList
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.helper.someCMStringList
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.CoalesceExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.IfMissingOrNullExpression
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfMissingOrNullTest {
+    @Test
+    fun `should support if missing or null with CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMNumberField CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val additionalExpression = someCMNumberField()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMStringField CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val additionalExpression = someCMStringField()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMBooleanField CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val additionalExpression = someCMBooleanField()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMNumberList CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val additionalExpression = someCMNumberList()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMStringList CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val additionalExpression = someCMStringList()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val expected = IfMissingOrNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing or null with CMBooleanList CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val additionalExpression = someCMBooleanList()
+        val expected = IfMissingOrNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissingOrNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMNumberField CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val additionalExpression = someCMNumberField()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMStringField CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val additionalExpression = someCMStringField()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMBooleanField CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val additionalExpression = someCMBooleanField()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMNumberList CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val additionalExpression = someCMNumberList()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMStringList CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val additionalExpression = someCMStringList()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val expected = CoalesceExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = coalesce(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support coalesce with CMBooleanList CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val additionalExpression = someCMBooleanList()
+        val expected = CoalesceExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = coalesce(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfMissingTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfMissingTest.kt
@@ -1,0 +1,177 @@
+package ch.ergon.dope.extensions.type.conditional
+
+import ch.ergon.dope.extension.type.conditional.ifMissing
+import ch.ergon.dope.helper.someCMBooleanField
+import ch.ergon.dope.helper.someCMBooleanList
+import ch.ergon.dope.helper.someCMNumberField
+import ch.ergon.dope.helper.someCMNumberList
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.helper.someCMStringList
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.IfMissingExpression
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfMissingTest {
+    @Test
+    fun `should support if missing with CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMNumberField CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val additionalExpression = someCMNumberField()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMStringField CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val additionalExpression = someCMStringField()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMBooleanField CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val additionalExpression = someCMBooleanField()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMNumberList CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val additionalExpression = someCMNumberList()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMStringList CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val additionalExpression = someCMStringList()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val expected = IfMissingExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifMissing(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if missing with CMBooleanList CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val additionalExpression = someCMBooleanList()
+        val expected = IfMissingExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifMissing(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfNullTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/IfNullTest.kt
@@ -1,0 +1,177 @@
+package ch.ergon.dope.extensions.type.conditional
+
+import ch.ergon.dope.extension.type.conditional.ifNull
+import ch.ergon.dope.helper.someCMBooleanField
+import ch.ergon.dope.helper.someCMBooleanList
+import ch.ergon.dope.helper.someCMNumberField
+import ch.ergon.dope.helper.someCMNumberList
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.helper.someCMStringList
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.IfNullExpression
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class IfNullTest {
+    @Test
+    fun `should support if null with CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMNumberField CMNumberField CMNumberField`() {
+        val firstExpression = someCMNumberField()
+        val secondExpression = someCMNumberField()
+        val additionalExpression = someCMNumberField()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMStringField CMStringField CMStringField`() {
+        val firstExpression = someCMStringField()
+        val secondExpression = someCMStringField()
+        val additionalExpression = someCMStringField()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMBooleanField CMBooleanField CMBooleanField`() {
+        val firstExpression = someCMBooleanField()
+        val secondExpression = someCMBooleanField()
+        val additionalExpression = someCMBooleanField()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMNumberList CMNumberList CMNumberList`() {
+        val firstExpression = someCMNumberList()
+        val secondExpression = someCMNumberList()
+        val additionalExpression = someCMNumberList()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMStringList CMStringList CMStringList`() {
+        val firstExpression = someCMStringList()
+        val secondExpression = someCMStringList()
+        val additionalExpression = someCMStringList()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val expected = IfNullExpression(firstExpression.toDopeType(), secondExpression.toDopeType())
+
+        val actual = ifNull(firstExpression, secondExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support if null with CMBooleanList CMBooleanList CMBooleanList`() {
+        val firstExpression = someCMBooleanList()
+        val secondExpression = someCMBooleanList()
+        val additionalExpression = someCMBooleanList()
+        val expected = IfNullExpression(
+            firstExpression.toDopeType(),
+            secondExpression.toDopeType(),
+            additionalExpression.toDopeType(),
+        )
+
+        val actual = ifNull(firstExpression, secondExpression, additionalExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/Nvl2Test.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/Nvl2Test.kt
@@ -1,0 +1,637 @@
+package ch.ergon.dope.extensions.type.conditional
+
+import ch.ergon.dope.extension.type.conditional.nvl2
+import ch.ergon.dope.helper.someBoolean
+import ch.ergon.dope.helper.someBooleanField
+import ch.ergon.dope.helper.someBooleanFieldList
+import ch.ergon.dope.helper.someCMBooleanField
+import ch.ergon.dope.helper.someCMBooleanList
+import ch.ergon.dope.helper.someCMNumberField
+import ch.ergon.dope.helper.someCMNumberList
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.helper.someCMStringList
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someNumberField
+import ch.ergon.dope.helper.someNumberFieldList
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.helper.someStringFieldList
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.Nvl2Expression
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Nvl2Test {
+    @Test
+    fun `should support nvl2 CMType CMNumberField CMNumberField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMStringField CMStringField`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMBooleanField CMBooleanField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMNumberList CMNumberList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMNumberList()
+        val valueIfNotExists = someCMNumberList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMStringList CMStringList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMStringList()
+        val valueIfNotExists = someCMStringList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMBooleanList CMBooleanList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMBooleanList()
+        val valueIfNotExists = someCMBooleanList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMNumberField unaliased number`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someNumberField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMStringField unaliased string`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someStringField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMBooleanField unaliased boolean`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someBooleanField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMNumberList unaliased number list`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMNumberList()
+        val valueIfNotExists = someNumberFieldList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMStringList unaliased string list`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMStringList()
+        val valueIfNotExists = someStringFieldList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMBooleanList unaliased boolean list`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMBooleanList()
+        val valueIfNotExists = someBooleanFieldList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMNumberField number`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someNumber()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMStringField string`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someString()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType CMBooleanField boolean`() {
+        val expression = someCMStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someBoolean()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased number CMNumberField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someNumberField()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased string CMStringField`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someStringField()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased boolean CMBooleanField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someBooleanField()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased number list CMNumberList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someNumberFieldList()
+        val valueIfNotExists = someCMNumberList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased string list CMStringList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someStringFieldList()
+        val valueIfNotExists = someCMStringList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType unaliased boolean list CMBooleanList`() {
+        val expression = someCMStringField()
+        val valueIfExists = someBooleanFieldList()
+        val valueIfNotExists = someCMBooleanList()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType number CMNumberField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someNumber()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType string CMStringField`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someString()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType boolean CMBooleanField`() {
+        val expression = someCMStringField()
+        val valueIfExists = someBoolean()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType number number`() {
+        val expression = someCMStringField()
+        val valueIfExists = someNumber()
+        val valueIfNotExists = someNumber()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType string string`() {
+        val expression = someCMNumberField()
+        val valueIfExists = someString()
+        val valueIfNotExists = someString()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 CMType boolean boolean`() {
+        val expression = someCMStringField()
+        val valueIfExists = someBoolean()
+        val valueIfNotExists = someBoolean()
+        val expected = Nvl2Expression(expression.toDopeType(), valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMNumberField CMNumberField`() {
+        val expression = someStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMStringField CMStringField`() {
+        val expression = someNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMBooleanField CMBooleanField`() {
+        val expression = someStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMNumberList CMNumberList`() {
+        val expression = someStringField()
+        val valueIfExists = someCMNumberList()
+        val valueIfNotExists = someCMNumberList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMStringList CMStringList`() {
+        val expression = someStringField()
+        val valueIfExists = someCMStringList()
+        val valueIfNotExists = someCMStringList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMBooleanList CMBooleanList`() {
+        val expression = someStringField()
+        val valueIfExists = someCMBooleanList()
+        val valueIfNotExists = someCMBooleanList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMNumberField unaliased number`() {
+        val expression = someStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someNumberField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMStringField unaliased string`() {
+        val expression = someNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someStringField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMBooleanField unaliased boolean`() {
+        val expression = someStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someBooleanField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMNumberList unaliased number list`() {
+        val expression = someStringField()
+        val valueIfExists = someCMNumberList()
+        val valueIfNotExists = someNumberFieldList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMStringList unaliased string list`() {
+        val expression = someStringField()
+        val valueIfExists = someCMStringList()
+        val valueIfNotExists = someStringFieldList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMBooleanList unaliased boolean list`() {
+        val expression = someStringField()
+        val valueIfExists = someCMBooleanList()
+        val valueIfNotExists = someBooleanFieldList()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists)
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMNumberField number`() {
+        val expression = someStringField()
+        val valueIfExists = someCMNumberField()
+        val valueIfNotExists = someNumber()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMStringField string`() {
+        val expression = someNumberField()
+        val valueIfExists = someCMStringField()
+        val valueIfNotExists = someString()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased CMBooleanField boolean`() {
+        val expression = someStringField()
+        val valueIfExists = someCMBooleanField()
+        val valueIfNotExists = someBoolean()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased number CMNumberField`() {
+        val expression = someStringField()
+        val valueIfExists = someNumberField()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased string CMStringField`() {
+        val expression = someNumberField()
+        val valueIfExists = someStringField()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased boolean CMBooleanField`() {
+        val expression = someStringField()
+        val valueIfExists = someBooleanField()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased number list CMNumberList`() {
+        val expression = someStringField()
+        val valueIfExists = someNumberFieldList()
+        val valueIfNotExists = someCMNumberList()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased string list CMStringList`() {
+        val expression = someStringField()
+        val valueIfExists = someStringFieldList()
+        val valueIfNotExists = someCMStringList()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased unaliased boolean list CMBooleanList`() {
+        val expression = someStringField()
+        val valueIfExists = someBooleanFieldList()
+        val valueIfNotExists = someCMBooleanList()
+        val expected = Nvl2Expression(expression, valueIfExists, valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased number CMNumberField`() {
+        val expression = someStringField()
+        val valueIfExists = someNumber()
+        val valueIfNotExists = someCMNumberField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased string CMStringField`() {
+        val expression = someNumberField()
+        val valueIfExists = someString()
+        val valueIfNotExists = someCMStringField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl2 unaliased boolean CMBooleanField`() {
+        val expression = someStringField()
+        val valueIfExists = someBoolean()
+        val valueIfNotExists = someCMBooleanField()
+        val expected = Nvl2Expression(expression, valueIfExists.toDopeType(), valueIfNotExists.toDopeType())
+
+        val actual = nvl2(expression, valueIfExists, valueIfNotExists)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/NvlTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/type/conditional/NvlTest.kt
@@ -1,0 +1,118 @@
+package ch.ergon.dope.extensions.type.conditional
+
+import ch.ergon.dope.extension.type.conditional.nvl
+import ch.ergon.dope.helper.someBoolean
+import ch.ergon.dope.helper.someCMBooleanField
+import ch.ergon.dope.helper.someCMBooleanList
+import ch.ergon.dope.helper.someCMNumberField
+import ch.ergon.dope.helper.someCMNumberList
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.helper.someCMStringList
+import ch.ergon.dope.helper.someNumber
+import ch.ergon.dope.helper.someString
+import ch.ergon.dope.resolvable.expression.unaliased.type.conditional.NvlExpression
+import ch.ergon.dope.resolvable.expression.unaliased.type.toDopeType
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NvlTest {
+    @Test
+    fun `should support nvl CMNumberField CMNumberField`() {
+        val initialExpression = someCMNumberField()
+        val substituteExpression = someCMNumberField()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMStringField CMStringField`() {
+        val initialExpression = someCMStringField()
+        val substituteExpression = someCMStringField()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMBooleanField CMBooleanField`() {
+        val initialExpression = someCMBooleanField()
+        val substituteExpression = someCMBooleanField()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMNumberList CMNumberList`() {
+        val initialExpression = someCMNumberList()
+        val substituteExpression = someCMNumberList()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMStringList CMStringList`() {
+        val initialExpression = someCMStringList()
+        val substituteExpression = someCMStringList()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMBooleanList CMBooleanList`() {
+        val initialExpression = someCMBooleanList()
+        val substituteExpression = someCMBooleanList()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMNumberField number`() {
+        val initialExpression = someCMNumberField()
+        val substituteExpression = someNumber()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMStringField string`() {
+        val initialExpression = someCMStringField()
+        val substituteExpression = someString()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+
+    @Test
+    fun `should support nvl CMBooleanField boolean`() {
+        val initialExpression = someCMBooleanField()
+        val substituteExpression = someBoolean()
+        val expected = NvlExpression(initialExpression.toDopeType(), substituteExpression.toDopeType())
+
+        val actual = nvl(initialExpression, substituteExpression)
+
+        assertEquals(expected.toDopeQuery(), actual.toDopeQuery())
+    }
+}


### PR DESCRIPTION
After a sync offline with @pgruntz, I purposefully left out the CM extension for `DECODE`, because it would needlessly overinflate. Every needed combination would amass to well over 100 functions.

A user can still profit from `DECODE` with the `.toDopeType()` function of CM types (type safety still applies).