### PR TITLE
DOPE-265: added search functions

### DIFF
--- a/core/src/integrationTest/kotlin/ch/ergon/dope/functions/SearchFunctionsIntegrationTest.kt
+++ b/core/src/integrationTest/kotlin/ch/ergon/dope/functions/SearchFunctionsIntegrationTest.kt
@@ -1,0 +1,40 @@
+package ch.ergon.dope.functions
+
+import ch.ergon.dope.QueryBuilder
+import ch.ergon.dope.integrationTest.BaseIntegrationTest
+import ch.ergon.dope.integrationTest.TestCouchbaseDatabase.testBucket
+import ch.ergon.dope.integrationTest.toMapValues
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearch
+import ch.ergon.dope.resolvable.expression.type.meta
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchFunctionsIntegrationTest : BaseIntegrationTest() {
+    @Test
+    fun `full text search type field`() {
+        val dopeQuery = QueryBuilder().select(
+            meta().id,
+        ).from(
+            testBucket,
+        ).where(
+            fullTextSearch(
+                testBucket,
+                mapOf(
+                    "query" to mapOf(
+                        "field" to "type",
+                        "match" to "order",
+                    ),
+                ),
+            ),
+        ).build()
+
+        val queryResult = queryWithoutParameters(dopeQuery)
+
+        assertEquals(5, queryResult.rows.size)
+        assertEquals(mapOf("id" to "order:1"), queryResult.toMapValues(rowNumber = 0))
+        assertEquals(mapOf("id" to "order:2"), queryResult.toMapValues(rowNumber = 1))
+        assertEquals(mapOf("id" to "order:3"), queryResult.toMapValues(rowNumber = 2))
+        assertEquals(mapOf("id" to "order:4"), queryResult.toMapValues(rowNumber = 3))
+        assertEquals(mapOf("id" to "order:5"), queryResult.toMapValues(rowNumber = 4))
+    }
+}

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/operator/FunctionOperator.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/operator/FunctionOperator.kt
@@ -8,6 +8,6 @@ interface FunctionOperator {
     fun toFunctionQueryString(symbol: String, vararg arguments: DopeQuery?) =
         formatListToQueryStringWithBrackets(arguments.filterNotNull(), prefix = "$symbol(")
 
-    fun toFunctionQueryString(symbol: String, vararg arguments: String) =
-        formatStringListToQueryStringWithBrackets(arguments.toList(), prefix = "$symbol(")
+    fun toFunctionQueryString(symbol: String, vararg arguments: String?) =
+        formatStringListToQueryStringWithBrackets(arguments.filterNotNull().toList(), prefix = "$symbol(")
 }

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/Primitive.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/Primitive.kt
@@ -98,7 +98,10 @@ fun List<ObjectEntryPrimitive<out ValidType>>.toDopeType(): ObjectPrimitive = Ob
 fun <V> Map<String, V>.toDopeType(): ObjectPrimitive =
     ObjectPrimitive(
         *map { (key, value) ->
-            key.toDopeType().toObjectEntry(value.toDopeType())
+            when (value) {
+                is TypeExpression<*> -> key.toDopeType().toObjectEntry(value)
+                else -> key.toDopeType().toObjectEntry(value.toDopeType())
+            }
         }.toTypedArray(),
     )
 

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/function/search/SearchDependencyFunctionExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/function/search/SearchDependencyFunctionExpression.kt
@@ -1,0 +1,33 @@
+package ch.ergon.dope.resolvable.expression.type.function.search
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.DopeQueryManager
+import ch.ergon.dope.resolvable.expression.operator.FunctionOperator
+import ch.ergon.dope.resolvable.expression.type.TypeExpression
+import ch.ergon.dope.validtype.NumberType
+import ch.ergon.dope.validtype.ObjectType
+import ch.ergon.dope.validtype.ValidType
+
+sealed class SearchDependencyFunctionExpression<T : ValidType>(
+    private val searchFunctionType: SearchFunctionType,
+    private val outName: String? = null,
+) : TypeExpression<T>, FunctionOperator {
+    override fun toDopeQuery(manager: DopeQueryManager): DopeQuery {
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                searchFunctionType.type,
+                outName?.let { "`$it`" },
+            ),
+        )
+    }
+}
+
+class SearchMetaFunctionExpression(outName: String? = null) :
+    SearchDependencyFunctionExpression<ObjectType>(SearchFunctionType.SEARCH_META, outName)
+
+class SearchScoreFunctionExpression(outName: String? = null) :
+    SearchDependencyFunctionExpression<NumberType>(SearchFunctionType.SEARCH_SCORE, outName)
+
+fun fullTextSearchMeta(outName: String? = null) = SearchMetaFunctionExpression(outName)
+
+fun fullTextSearchScore(outName: String? = null) = SearchScoreFunctionExpression(outName)

--- a/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/function/search/SearchFunctionExpression.kt
+++ b/core/src/main/kotlin/ch/ergon/dope/resolvable/expression/type/function/search/SearchFunctionExpression.kt
@@ -1,0 +1,130 @@
+package ch.ergon.dope.resolvable.expression.type.function.search
+
+import ch.ergon.dope.DopeParameters
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.DopeQueryManager
+import ch.ergon.dope.resolvable.bucket.Bucket
+import ch.ergon.dope.resolvable.expression.operator.FunctionOperator
+import ch.ergon.dope.resolvable.expression.type.Field
+import ch.ergon.dope.resolvable.expression.type.TypeExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFunctionType.SEARCH
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFunctionType.SEARCH_META
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFunctionType.SEARCH_SCORE
+import ch.ergon.dope.resolvable.expression.type.toDopeType
+import ch.ergon.dope.validtype.BooleanType
+import ch.ergon.dope.validtype.NumberType
+import ch.ergon.dope.validtype.ObjectType
+import ch.ergon.dope.validtype.ValidType
+
+enum class SearchFunctionType(val type: String) {
+    SEARCH("SEARCH"),
+    SEARCH_META("SEARCH_META"),
+    SEARCH_SCORE("SEARCH_SCORE"),
+}
+
+sealed class SearchFunctionExpression(
+    private val identifier: Field<out ValidType>? = null,
+    private val keyspaceIdentifier: Bucket? = null,
+    private val stringSearchQuery: String? = null,
+    private val objectSearchQuery: Map<String, Any>? = null,
+    private val options: Map<String, Any>? = null,
+) : TypeExpression<BooleanType>, FunctionOperator {
+    override fun toDopeQuery(manager: DopeQueryManager): DopeQuery {
+        val identifierDopeQuery = identifier?.toDopeQuery(manager)
+        val keyspaceIdentifierDopeQuery = keyspaceIdentifier?.toDopeQuery(manager)
+        val stringSearchQueryDopeQuery = stringSearchQuery?.toDopeType()?.toDopeQuery(manager)
+        val objectSearchQuery = objectSearchQuery?.toDopeType()?.toDopeQuery(manager)
+        val optionsDopeQuery = options?.toDopeType()?.toDopeQuery(manager)
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                SEARCH.type,
+                identifierDopeQuery,
+                keyspaceIdentifierDopeQuery,
+                stringSearchQueryDopeQuery,
+                objectSearchQuery,
+                optionsDopeQuery,
+            ),
+            parameters = (identifierDopeQuery?.parameters ?: DopeParameters()).merge(
+                keyspaceIdentifierDopeQuery?.parameters,
+                objectSearchQuery?.parameters,
+                optionsDopeQuery?.parameters,
+            ),
+        )
+    }
+}
+
+class SearchFieldStringFunctionExpression(
+    identifier: Field<out ValidType>,
+    searchQuery: String,
+    options: Map<String, Any>? = null,
+) : SearchFunctionExpression(
+    identifier = identifier,
+    stringSearchQuery = searchQuery,
+    options = options,
+)
+
+fun fullTextSearch(identifier: Field<out ValidType>, searchQuery: String, options: Map<String, Any>? = null) =
+    SearchFieldStringFunctionExpression(identifier, searchQuery, options)
+
+class SearchBucketStringFunctionExpression(
+    identifier: Bucket,
+    searchQuery: String,
+    options: Map<String, Any>? = null,
+) : SearchFunctionExpression(
+    keyspaceIdentifier = identifier,
+    stringSearchQuery = searchQuery,
+    options = options,
+)
+
+fun fullTextSearch(identifier: Bucket, searchQuery: String, options: Map<String, Any>? = null) =
+    SearchBucketStringFunctionExpression(identifier, searchQuery, options)
+
+class SearchFieldObjectFunctionExpression(
+    identifier: Field<out ValidType>,
+    searchQuery: Map<String, Any>,
+    options: Map<String, Any>? = null,
+) : SearchFunctionExpression(
+    identifier = identifier,
+    objectSearchQuery = searchQuery,
+    options = options,
+)
+
+fun fullTextSearch(identifier: Field<out ValidType>, searchQuery: Map<String, Any>, options: Map<String, Any>? = null) =
+    SearchFieldObjectFunctionExpression(identifier, searchQuery, options)
+
+class SearchBucketObjectFunctionExpression(
+    identifier: Bucket,
+    searchQuery: Map<String, Any>,
+    options: Map<String, Any>? = null,
+) : SearchFunctionExpression(
+    keyspaceIdentifier = identifier,
+    objectSearchQuery = searchQuery,
+    options = options,
+)
+
+fun fullTextSearch(identifier: Bucket, searchQuery: Map<String, Any>, options: Map<String, Any>? = null) =
+    SearchBucketObjectFunctionExpression(identifier, searchQuery, options)
+
+sealed class SearchDependencyFunctionExpression<T : ValidType>(
+    private val searchFunctionType: SearchFunctionType,
+    private val outName: String? = null,
+) : TypeExpression<T>, FunctionOperator {
+    override fun toDopeQuery(manager: DopeQueryManager): DopeQuery {
+        return DopeQuery(
+            queryString = toFunctionQueryString(
+                searchFunctionType.type,
+                outName?.let { "`$it`" },
+            ),
+        )
+    }
+}
+
+class SearchMetaFunctionExpression(outName: String? = null) :
+    SearchDependencyFunctionExpression<ObjectType>(SEARCH_META, outName)
+
+fun fullTextSearchMeta(outName: String? = null) = SearchMetaFunctionExpression(outName)
+
+class SearchScoreFunctionExpression(outName: String? = null) :
+    SearchDependencyFunctionExpression<NumberType>(SEARCH_SCORE, outName)
+
+fun fullTextSearchScore(outName: String? = null) = SearchScoreFunctionExpression(outName)

--- a/core/src/test/kotlin/ch/ergon/dope/buildTest/SearchFunctionsTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/buildTest/SearchFunctionsTest.kt
@@ -25,15 +25,16 @@ class SearchFunctionsTest : ManagerDependentTest {
 
     @Test
     fun `should support search function on field and string query`() {
+        val bucket = someBucket()
         val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`.`stringField`, \"+something\")"
 
         val actual = create.select(
             meta().id,
         ).from(
-            someBucket(),
+            bucket,
         ).where(
             fullTextSearch(
-                someStringField(bucket = someBucket()),
+                someStringField(bucket = bucket),
                 "+something",
             ),
         ).build().queryString
@@ -43,15 +44,16 @@ class SearchFunctionsTest : ManagerDependentTest {
 
     @Test
     fun `should support search function on bucket with string query`() {
+        val bucket = someBucket()
         val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`, \"stringField:\"something\"\")"
 
         val actual = create.select(
             meta().id,
         ).from(
-            someBucket(),
+            bucket,
         ).where(
             fullTextSearch(
-                someBucket(),
+                bucket,
                 "stringField:\"something\"",
             ),
         ).build().queryString
@@ -81,6 +83,7 @@ class SearchFunctionsTest : ManagerDependentTest {
 
     @Test
     fun `should support search function on bucket with object query`() {
+        val bucket = someBucket()
         val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`, {\"disjuncts\" : " +
             "[{\"regexp\" : \"(?i).*123.*\", \"field\" : \"someField\"}, " +
             "{\"regexp\" : \"(?i).*123.*\", \"field\" : \"anotherField\"}]}) " +
@@ -90,10 +93,10 @@ class SearchFunctionsTest : ManagerDependentTest {
             .select(
                 meta().id,
             ).from(
-                someBucket(),
+                bucket,
             ).where(
                 fullTextSearch(
-                    someBucket(),
+                    bucket,
                     mapOf(
                         "disjuncts" to listOf(
                             mapOf("regexp" to "(?i).*123.*", "field" to "someField"),

--- a/core/src/test/kotlin/ch/ergon/dope/buildTest/SearchFunctionsTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/buildTest/SearchFunctionsTest.kt
@@ -1,0 +1,150 @@
+package ch.ergon.dope.buildTest
+
+import ch.ergon.dope.DopeQueryManager
+import ch.ergon.dope.QueryBuilder
+import ch.ergon.dope.helper.ManagerDependentTest
+import ch.ergon.dope.helper.someBucket
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.type.alias
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearch
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearchMeta
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearchScore
+import ch.ergon.dope.resolvable.expression.type.meta
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchFunctionsTest : ManagerDependentTest {
+    override lateinit var manager: DopeQueryManager
+    private lateinit var create: QueryBuilder
+
+    @BeforeTest
+    fun setup() {
+        create = QueryBuilder()
+    }
+
+    @Test
+    fun `should support search function on field and string query`() {
+        val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`.`stringField`, \"+something\")"
+
+        val actual = create.select(
+            meta().id,
+        ).from(
+            someBucket(),
+        ).where(
+            fullTextSearch(
+                someStringField(bucket = someBucket()),
+                "+something",
+            ),
+        ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search function on bucket with string query`() {
+        val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`, \"stringField:\"something\"\")"
+
+        val actual = create.select(
+            meta().id,
+        ).from(
+            someBucket(),
+        ).where(
+            fullTextSearch(
+                someBucket(),
+                "stringField:\"something\"",
+            ),
+        ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search function on field with object query`() {
+        val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`stringField`, {\"match\" : \"something\"})"
+
+        val actual = create.select(
+            meta().id,
+        ).from(
+            someBucket(),
+        ).where(
+            fullTextSearch(
+                someStringField(),
+                mapOf(
+                    "match" to "something",
+                ),
+            ),
+        ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search function on bucket with object query`() {
+        val expected = "SELECT META().`id` FROM `someBucket` WHERE SEARCH(`someBucket`, {\"disjuncts\" : " +
+            "[{\"regexp\" : \"(?i).*123.*\", \"field\" : \"someField\"}, " +
+            "{\"regexp\" : \"(?i).*123.*\", \"field\" : \"anotherField\"}]}) " +
+            "LIMIT 10"
+
+        val actual = create
+            .select(
+                meta().id,
+            ).from(
+                someBucket(),
+            ).where(
+                fullTextSearch(
+                    someBucket(),
+                    mapOf(
+                        "disjuncts" to listOf(
+                            mapOf("regexp" to "(?i).*123.*", "field" to "someField"),
+                            mapOf("regexp" to "(?i).*123.*", "field" to "anotherField"),
+                        ),
+                    ),
+                ),
+            ).limit(10).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search score function on specified out name`() {
+        val expected = "SELECT META().`id`, SEARCH_SCORE(`outName`) AS `score` FROM `someBucket` " +
+            "WHERE SEARCH(`stringField`, \"+something\", {\"out\" : \"outName\"})"
+
+        val actual = create.select(
+            meta().id,
+            fullTextSearchScore("outName").alias("score"),
+        ).from(
+            someBucket(),
+        ).where(
+            fullTextSearch(
+                someStringField(),
+                "+something",
+                mapOf(
+                    "out" to "outName",
+                ),
+            ),
+        ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search score function on implicit out name`() {
+        val expected = "SELECT SEARCH_META() AS `meta` FROM `someBucket` " +
+            "WHERE SEARCH(`stringField`, \"+something\")"
+
+        val actual = create.select(
+            fullTextSearchMeta().alias("meta"),
+        ).from(
+            someBucket(),
+        ).where(
+            fullTextSearch(
+                someStringField(),
+                "+something",
+            ),
+        ).build().queryString
+
+        assertEquals(expected, actual)
+    }
+}

--- a/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/type/function/searchfunction/SearchFunctionExpressionTest.kt
+++ b/core/src/test/kotlin/ch/ergon/dope/resolvable/expression/type/function/searchfunction/SearchFunctionExpressionTest.kt
@@ -1,0 +1,327 @@
+package ch.ergon.dope.resolvable.expression.type.function.searchfunction
+
+import ch.ergon.dope.DopeQuery
+import ch.ergon.dope.DopeQueryManager
+import ch.ergon.dope.helper.ManagerDependentTest
+import ch.ergon.dope.helper.someBucket
+import ch.ergon.dope.helper.someStringField
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchBucketObjectFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchBucketStringFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldObjectFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldStringFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchMetaFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchScoreFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearch
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearchMeta
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearchScore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchFunctionExpressionTest : ManagerDependentTest {
+    override lateinit var manager: DopeQueryManager
+
+    @Test
+    fun `should support search string function expression on field`() {
+        val field = someStringField(bucket = someBucket())
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`.`stringField`, \"someString\")",
+        )
+        val underTest = SearchFieldStringFunctionExpression(field, "someString")
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search string function expression on field with options`() {
+        val field = someStringField(bucket = someBucket())
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`.`stringField`, \"+someString\", {\"index\" : \"someIndex\"})",
+        )
+        val underTest = SearchFieldStringFunctionExpression(
+            field,
+            searchQuery = "+someString",
+            options = mapOf("index" to "someIndex"),
+        )
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search string function extension on field`() {
+        val field = someStringField(bucket = someBucket())
+        val searchQuery = "+someString"
+        val expected = SearchFieldStringFunctionExpression(field, searchQuery)
+
+        val actual = fullTextSearch(field, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search string function extension on field with options`() {
+        val field = someStringField(bucket = someBucket())
+        val searchQuery = "+someString"
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchFieldStringFunctionExpression(field, searchQuery, options)
+
+        val actual = fullTextSearch(field, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search string function expression on bucket`() {
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`, \"field:\"someString\"\")",
+        )
+        val underTest = SearchBucketStringFunctionExpression(
+            someBucket(),
+            searchQuery = "field:\"someString\"",
+        )
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search string function expression on bucket with options`() {
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`, \"field:\"someString\"\", {\"index\" : \"someIndex\"})",
+        )
+        val underTest = SearchBucketStringFunctionExpression(
+            someBucket(),
+            searchQuery = "field:\"someString\"",
+            options = mapOf("index" to "someIndex"),
+        )
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search string function extension on bucket`() {
+        val bucket = someBucket()
+        val searchQuery = "field:\"someString\""
+        val expected = SearchBucketStringFunctionExpression(bucket, searchQuery)
+
+        val actual = fullTextSearch(bucket, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search string function extension on bucket with options`() {
+        val bucket = someBucket()
+        val searchQuery = "field:\"someString\""
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchBucketStringFunctionExpression(bucket, searchQuery, options)
+
+        val actual = fullTextSearch(bucket, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search object function expression`() {
+        val field = someStringField(bucket = someBucket())
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`.`stringField`, {\"field\" : \"someField\", \"analyzer\" : \"standard\"})",
+        )
+        val underTest = SearchFieldObjectFunctionExpression(field, mapOf("field" to "someField", "analyzer" to "standard"))
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search object function expression with options`() {
+        val field = someStringField(bucket = someBucket())
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`.`stringField`, " +
+                "{\"field\" : \"someField\", \"analyzer\" : \"standard\"}, " +
+                "{\"index\" : \"someIndex\"})",
+        )
+        val underTest = SearchFieldObjectFunctionExpression(
+            field,
+            mapOf("field" to "someField", "analyzer" to "standard"),
+            mapOf("index" to "someIndex"),
+        )
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search object function extension`() {
+        val field = someStringField(bucket = someBucket())
+        val searchQuery = mapOf("field" to "someField", "analyzer" to "standard")
+        val expected = SearchFieldObjectFunctionExpression(field, searchQuery)
+
+        val actual = fullTextSearch(field, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search object function extension with options`() {
+        val field = someStringField(bucket = someBucket())
+        val searchQuery = mapOf("field" to "someField", "analyzer" to "standard")
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchFieldObjectFunctionExpression(field, searchQuery, options)
+
+        val actual = fullTextSearch(field, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search object function expression on bucket`() {
+        val bucket = someBucket()
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`, {\"field\" : \"someField\", \"analyzer\" : \"standard\"})",
+        )
+        val underTest = SearchBucketObjectFunctionExpression(bucket, mapOf("field" to "someField", "analyzer" to "standard"))
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search object function expression on bucket with options`() {
+        val bucket = someBucket()
+        val expected = DopeQuery(
+            queryString = "SEARCH(`someBucket`, " +
+                "{\"field\" : \"someField\", \"analyzer\" : \"standard\"}, " +
+                "{\"index\" : \"someIndex\"})",
+        )
+        val underTest = SearchBucketObjectFunctionExpression(
+            bucket,
+            mapOf("field" to "someField", "analyzer" to "standard"),
+            mapOf("index" to "someIndex"),
+        )
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search object function extension on bucket`() {
+        val bucket = someBucket()
+        val searchQuery = mapOf("field" to "someField", "analyzer" to "standard")
+        val expected = SearchBucketObjectFunctionExpression(bucket, searchQuery)
+
+        val actual = fullTextSearch(bucket, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search object function extension on bucket with options`() {
+        val bucket = someBucket()
+        val searchQuery = mapOf("field" to "someField", "analyzer" to "standard")
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchBucketObjectFunctionExpression(bucket, searchQuery, options)
+
+        val actual = fullTextSearch(bucket, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search meta function expression`() {
+        val expected = DopeQuery(
+            queryString = "SEARCH_META()",
+        )
+        val underTest = SearchMetaFunctionExpression()
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search meta function expression with specified out name`() {
+        val outName = "outName"
+        val expected = DopeQuery(
+            queryString = "SEARCH_META(`$outName`)",
+        )
+        val underTest = SearchMetaFunctionExpression(outName)
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search meta function extension`() {
+        val expected = SearchMetaFunctionExpression()
+
+        val actual = fullTextSearchMeta()
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search meta function extension with specified out name`() {
+        val outName = "outName"
+        val expected = SearchMetaFunctionExpression(outName)
+
+        val actual = fullTextSearchMeta(outName)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search score function expression`() {
+        val expected = DopeQuery(
+            queryString = "SEARCH_SCORE()",
+        )
+        val underTest = SearchScoreFunctionExpression()
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search score function expression with specified out name`() {
+        val outName = "outName"
+        val expected = DopeQuery(
+            queryString = "SEARCH_SCORE(`$outName`)",
+        )
+        val underTest = SearchScoreFunctionExpression(outName)
+
+        val actual = underTest.toDopeQuery(manager)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should support search score function extension`() {
+        val expected = SearchScoreFunctionExpression()
+
+        val actual = fullTextSearchScore()
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support search score function extension with specified out name`() {
+        val outName = "outName"
+        val expected = SearchScoreFunctionExpression(outName)
+
+        val actual = fullTextSearchScore(outName)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+}

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/expression/type/function/search/FullTextSearch.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/expression/type/function/search/FullTextSearch.kt
@@ -1,0 +1,11 @@
+package ch.ergon.dope.extension.expression.type.function.search
+
+import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearch
+import ch.ergon.dope.toDopeType
+import com.schwarz.crystalapi.schema.CMJsonField
+
+fun fullTextSearch(identifier: CMJsonField<String>, searchQuery: String, options: Map<String, Any>? = null) =
+    fullTextSearch(identifier.toDopeType(), searchQuery, options)
+
+fun fullTextSearch(identifier: CMJsonField<String>, searchQuery: Map<String, Any>, options: Map<String, Any>? = null) =
+    fullTextSearch(identifier.toDopeType(), searchQuery, options)

--- a/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/expression/type/function/search/FullTextSearch.kt
+++ b/crystal-map-connector/src/main/kotlin/ch/ergon/dope/extension/expression/type/function/search/FullTextSearch.kt
@@ -4,8 +4,8 @@ import ch.ergon.dope.resolvable.expression.type.function.search.fullTextSearch
 import ch.ergon.dope.toDopeType
 import com.schwarz.crystalapi.schema.CMJsonField
 
-fun fullTextSearch(identifier: CMJsonField<String>, searchQuery: String, options: Map<String, Any>? = null) =
-    fullTextSearch(identifier.toDopeType(), searchQuery, options)
+fun fullTextSearch(field: CMJsonField<String>, stringSearchExpression: String, options: Map<String, Any>? = null) =
+    fullTextSearch(field.toDopeType(), stringSearchExpression, options)
 
-fun fullTextSearch(identifier: CMJsonField<String>, searchQuery: Map<String, Any>, options: Map<String, Any>? = null) =
-    fullTextSearch(identifier.toDopeType(), searchQuery, options)
+fun fullTextSearch(field: CMJsonField<String>, objectSearchExpression: Map<String, Any>, options: Map<String, Any>? = null) =
+    fullTextSearch(field.toDopeType(), objectSearchExpression, options)

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/expression/type/function/search/SearchFunctionTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/expression/type/function/search/SearchFunctionTest.kt
@@ -4,8 +4,7 @@ import ch.ergon.dope.DopeQueryManager
 import ch.ergon.dope.extension.expression.type.function.search.fullTextSearch
 import ch.ergon.dope.helper.ManagerDependentTest
 import ch.ergon.dope.helper.someCMStringField
-import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldObjectFunctionExpression
-import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldStringFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFunctionExpression
 import ch.ergon.dope.toDopeType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,7 +16,7 @@ class SearchFunctionTest : ManagerDependentTest {
     fun `should support full text search function with string search query`() {
         val field = someCMStringField()
         val searchQuery = "+something"
-        val expected = SearchFieldStringFunctionExpression(field.toDopeType(), searchQuery)
+        val expected = SearchFunctionExpression(field.toDopeType(), searchQuery)
 
         val actual = fullTextSearch(field, searchQuery)
 
@@ -29,7 +28,7 @@ class SearchFunctionTest : ManagerDependentTest {
         val field = someCMStringField()
         val searchQuery = "+something"
         val options = mapOf("index" to "someIndex")
-        val expected = SearchFieldStringFunctionExpression(field.toDopeType(), searchQuery, options)
+        val expected = SearchFunctionExpression(field.toDopeType(), searchQuery, options)
 
         val actual = fullTextSearch(field, searchQuery, options)
 
@@ -40,7 +39,7 @@ class SearchFunctionTest : ManagerDependentTest {
     fun `should support full text search function with object search query`() {
         val field = someCMStringField()
         val searchQuery = mapOf("match" to "someString")
-        val expected = SearchFieldObjectFunctionExpression(field.toDopeType(), searchQuery)
+        val expected = SearchFunctionExpression(field.toDopeType(), searchQuery)
 
         val actual = fullTextSearch(field, searchQuery)
 
@@ -52,7 +51,7 @@ class SearchFunctionTest : ManagerDependentTest {
         val field = someCMStringField()
         val searchQuery = mapOf("match" to "someString")
         val options = mapOf("index" to "someIndex")
-        val expected = SearchFieldObjectFunctionExpression(field.toDopeType(), searchQuery, options)
+        val expected = SearchFunctionExpression(field.toDopeType(), searchQuery, options)
 
         val actual = fullTextSearch(field, searchQuery, options)
 

--- a/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/expression/type/function/search/SearchFunctionTest.kt
+++ b/crystal-map-connector/src/test/kotlin/ch/ergon/dope/extensions/expression/type/function/search/SearchFunctionTest.kt
@@ -1,0 +1,61 @@
+package ch.ergon.dope.extensions.expression.type.function.search
+
+import ch.ergon.dope.DopeQueryManager
+import ch.ergon.dope.extension.expression.type.function.search.fullTextSearch
+import ch.ergon.dope.helper.ManagerDependentTest
+import ch.ergon.dope.helper.someCMStringField
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldObjectFunctionExpression
+import ch.ergon.dope.resolvable.expression.type.function.search.SearchFieldStringFunctionExpression
+import ch.ergon.dope.toDopeType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SearchFunctionTest : ManagerDependentTest {
+    override lateinit var manager: DopeQueryManager
+
+    @Test
+    fun `should support full text search function with string search query`() {
+        val field = someCMStringField()
+        val searchQuery = "+something"
+        val expected = SearchFieldStringFunctionExpression(field.toDopeType(), searchQuery)
+
+        val actual = fullTextSearch(field, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support full text search function with string search query and options`() {
+        val field = someCMStringField()
+        val searchQuery = "+something"
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchFieldStringFunctionExpression(field.toDopeType(), searchQuery, options)
+
+        val actual = fullTextSearch(field, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support full text search function with object search query`() {
+        val field = someCMStringField()
+        val searchQuery = mapOf("match" to "someString")
+        val expected = SearchFieldObjectFunctionExpression(field.toDopeType(), searchQuery)
+
+        val actual = fullTextSearch(field, searchQuery)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+
+    @Test
+    fun `should support full text search function with object search query and options`() {
+        val field = someCMStringField()
+        val searchQuery = mapOf("match" to "someString")
+        val options = mapOf("index" to "someIndex")
+        val expected = SearchFieldObjectFunctionExpression(field.toDopeType(), searchQuery, options)
+
+        val actual = fullTextSearch(field, searchQuery, options)
+
+        assertEquals(expected.toDopeQuery(manager), actual.toDopeQuery(manager))
+    }
+}


### PR DESCRIPTION
Added search functions according to https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/searchfun.html#search

I didn't add meta or score in the integration test because a full text search index would need to be created to execute those queries.